### PR TITLE
Implement typed stores

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -65,14 +65,14 @@ impl<S: Default + ProvableStore + 'static> BaseCoinApp<S> {
         let store = SharedStore::new(RevertibleStore::new(store));
         // `SubStore` guarantees modules exclusive access to all paths in the store key-space.
         let modules: Vec<Box<dyn Module<ModuleStore<S>>>> = vec![
-            Box::new(Bank::new(SubStore::new(
+            Box::new(Bank::new(SharedStore::new(SubStore::new(
                 store.clone(),
                 prefix::Bank {}.identifier(),
-            )?)),
-            Box::new(Ibc::new(SubStore::new(
+            )?))),
+            Box::new(Ibc::new(SharedStore::new(SubStore::new(
                 store.clone(),
                 prefix::Ibc {}.identifier(),
-            )?)),
+            )?))),
         ];
         Ok(Self {
             store,

--- a/src/app/modules/auth.rs
+++ b/src/app/modules/auth.rs
@@ -1,18 +1,204 @@
-use crate::app::store::ProvableStore;
-use crate::app::BaseCoinApp;
+use crate::app::store::{
+    Height, Path, ProtobufStore, ProvableStore, SharedStore, Store, TypedStore,
+};
+use crate::prostgen::cosmos::auth::v1beta1::BaseAccount;
 use crate::prostgen::cosmos::auth::v1beta1::{
-    query_server::Query as AuthQuery, QueryAccountRequest, QueryAccountResponse,
-    QueryAccountsRequest, QueryAccountsResponse, QueryParamsRequest as AuthQueryParamsRequest,
-    QueryParamsResponse as AuthQueryParamsResponse,
+    query_server::{Query, QueryServer},
+    QueryAccountRequest, QueryAccountResponse, QueryAccountsRequest, QueryAccountsResponse,
+    QueryParamsRequest, QueryParamsResponse,
 };
 
+use std::convert::{TryFrom, TryInto};
+
+use cosmrs::AccountId;
 use prost::Message;
 use prost_types::Any;
+use tendermint_proto::Protobuf;
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
+#[derive(Clone)]
+struct AccountsPath(AccountId);
+
+impl From<AccountsPath> for Path {
+    fn from(path: AccountsPath) -> Self {
+        format!("accounts/{}", path.0).try_into().unwrap() // safety - cannot fail as AccountsPath is correct-by-construction
+    }
+}
+
+pub trait Account {
+    type Address;
+    type PubKey;
+
+    fn address(&self) -> &Self::Address;
+    fn pub_key(&self) -> &Self::PubKey;
+    fn number(&self) -> u64;
+    fn sequence(&self) -> u64;
+}
+
+#[derive(Clone)]
+pub struct AuthAccount {
+    address: AccountId,
+    number: u64,
+    sequence: u64,
+}
+
+impl AuthAccount {
+    pub fn new(address: AccountId) -> Self {
+        Self {
+            address,
+            number: 0,
+            sequence: 0,
+        }
+    }
+}
+
+impl Account for AuthAccount {
+    type Address = AccountId;
+    type PubKey = Vec<u8>;
+
+    fn address(&self) -> &Self::Address {
+        &self.address
+    }
+
+    fn pub_key(&self) -> &Self::PubKey {
+        unimplemented!()
+    }
+
+    fn number(&self) -> u64 {
+        self.number
+    }
+
+    fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+impl Protobuf<BaseAccount> for AuthAccount {}
+
+impl TryFrom<BaseAccount> for AuthAccount {
+    type Error = String;
+
+    fn try_from(account: BaseAccount) -> Result<Self, Self::Error> {
+        Ok(AuthAccount {
+            address: account
+                .address
+                .parse()
+                .map_err(|_| "Failed to parse address".to_string())?,
+            number: account.account_number,
+            sequence: account.sequence,
+        })
+    }
+}
+
+impl From<AuthAccount> for BaseAccount {
+    fn from(account: AuthAccount) -> Self {
+        BaseAccount {
+            address: account.address.to_string(),
+            pub_key: None,
+            account_number: account.number,
+            sequence: account.sequence,
+        }
+    }
+}
+
+impl From<AuthAccount> for Any {
+    fn from(account: AuthAccount) -> Self {
+        let account = BaseAccount::from(account);
+        Any {
+            type_url: "/cosmos.auth.v1beta1.BaseAccount".to_string(),
+            value: account.encode_to_vec(),
+        }
+    }
+}
+
+pub trait AccountReader {
+    type Error;
+    type Address;
+    type Account: Account;
+
+    fn get_account(&self, address: Self::Address) -> Result<Self::Account, Self::Error>;
+}
+
+pub trait AccountKeeper {
+    type Error;
+    type Account: Account;
+
+    fn set_account(&mut self, account: Self::Account) -> Result<(), Self::Error>;
+
+    fn remove_account(&mut self, account: Self::Account) -> Result<(), Self::Error>;
+}
+
+pub struct Auth<S> {
+    store: SharedStore<S>,
+}
+
+impl<S: 'static + ProvableStore> Auth<S> {
+    pub fn new(store: SharedStore<S>) -> Self {
+        Self { store }
+    }
+
+    pub fn query(&self) -> QueryServer<AuthQuery<S>> {
+        QueryServer::new(AuthQuery {
+            account_reader: self.account_reader(),
+        })
+    }
+
+    pub fn account_reader(&self) -> AuthAccountReader<S> {
+        AuthAccountReader {
+            account_store: TypedStore::new(self.store.clone()),
+        }
+    }
+
+    pub fn account_keeper(&self) -> AuthAccountKeeper<S> {
+        AuthAccountKeeper {
+            account_store: TypedStore::new(self.store.clone()),
+        }
+    }
+}
+
+pub struct AuthAccountReader<S> {
+    account_store: ProtobufStore<SharedStore<S>, AccountsPath, AuthAccount, BaseAccount>,
+}
+
+impl<S: Store> AccountReader for AuthAccountReader<S> {
+    type Error = ();
+    type Address = AccountId;
+    type Account = AuthAccount;
+
+    fn get_account(&self, address: Self::Address) -> Result<Self::Account, Self::Error> {
+        self.account_store
+            .get(Height::Pending, &AccountsPath(address))
+            .ok_or(())
+    }
+}
+
+pub struct AuthAccountKeeper<S> {
+    account_store: ProtobufStore<SharedStore<S>, AccountsPath, AuthAccount, BaseAccount>,
+}
+
+impl<S: Store> AccountKeeper for AuthAccountKeeper<S> {
+    type Error = ();
+    type Account = AuthAccount;
+
+    fn set_account(&mut self, account: Self::Account) -> Result<(), Self::Error> {
+        self.account_store
+            .set(AccountsPath(account.address().clone()), account)
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    fn remove_account(&mut self, _account: Self::Account) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}
+
+pub struct AuthQuery<S> {
+    account_reader: AuthAccountReader<S>,
+}
+
 #[tonic::async_trait]
-impl<S: ProvableStore + 'static> AuthQuery for BaseCoinApp<S> {
+impl<S: ProvableStore + 'static> Query for AuthQuery<S> {
     async fn accounts(
         &self,
         _request: Request<QueryAccountsRequest>,
@@ -26,23 +212,19 @@ impl<S: ProvableStore + 'static> AuthQuery for BaseCoinApp<S> {
     ) -> Result<Response<QueryAccountResponse>, Status> {
         debug!("Got auth account request");
 
-        let mut account = self.account.write().unwrap();
-        let mut buf = Vec::new();
-        account.encode(&mut buf).unwrap(); // safety - cannot fail since buf is a vector
+        let account_id = AccountId::new("basecoin", Default::default()).unwrap();
+        let mut account = self.account_reader.get_account(account_id).unwrap();
         account.sequence += 1;
 
         Ok(Response::new(QueryAccountResponse {
-            account: Some(Any {
-                type_url: "/cosmos.auth.v1beta1.BaseAccount".to_string(),
-                value: buf,
-            }),
+            account: Some(account.into()),
         }))
     }
 
     async fn params(
         &self,
-        _request: Request<AuthQueryParamsRequest>,
-    ) -> Result<Response<AuthQueryParamsResponse>, Status> {
+        _request: Request<QueryParamsRequest>,
+    ) -> Result<Response<QueryParamsResponse>, Status> {
         unimplemented!()
     }
 }

--- a/src/app/modules/bank.rs
+++ b/src/app/modules/bank.rs
@@ -194,7 +194,7 @@ impl<S: Store> Module<S> for Bank<S> {
         {
             None => Err(Error::non_existent_account(account_id).into()),
             Some(balance) => Ok(QueryResult {
-                data: JsonCodec::encode(balance).unwrap().into_bytes(),
+                data: JsonCodec::encode(&balance).unwrap().into_bytes(),
                 proof: None,
             }),
         }

--- a/src/app/modules/bank.rs
+++ b/src/app/modules/bank.rs
@@ -75,8 +75,7 @@ pub struct Bank<S> {
 }
 
 impl<S: ProvableStore + Default> Bank<SubStore<S>> {
-    pub fn new(store: SubStore<S>) -> Self {
-        let store = SharedStore::new(store);
+    pub fn new(store: SharedStore<SubStore<S>>) -> Self {
         Self {
             store: store.clone(),
             account_store: SubStore::typed_store(store),

--- a/src/app/modules/bank.rs
+++ b/src/app/modules/bank.rs
@@ -1,3 +1,4 @@
+use crate::app::modules::auth::{AccountKeeper, AccountReader, AuthAccount};
 use crate::app::modules::{Error as ModuleError, Module, QueryResult};
 use crate::app::store::{
     Codec, Height, JsonCodec, JsonStore, Path, ProvableStore, SharedStore, Store, TypedStore,
@@ -9,16 +10,13 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use cosmrs::bank::MsgSend;
-use cosmrs::{proto, AccountId};
+use cosmrs::{proto, AccountId, Coin as MsgCoin};
 use flex_error::{define_error, TraceError};
 use prost::{DecodeError, Message};
 use prost_types::Any;
 use serde::{Deserialize, Serialize};
 use tendermint_proto::abci::Event;
 use tracing::{debug, trace};
-
-/// A currency denomination.
-pub type Denom = String;
 
 define_error! {
     #[derive(Eq, PartialEq)]
@@ -51,39 +49,141 @@ impl From<Error> for ModuleError {
     }
 }
 
-/// A mapping of currency denomination identifiers to balances.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Hash, Eq)]
 #[serde(transparent)]
-pub struct Balances(HashMap<Denom, u64>);
+pub struct Denom(String);
 
-#[derive(Clone)]
-struct AccountsPath(AccountId);
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct Coin {
+    pub denom: Denom,
+    pub amount: u64,
+}
 
-impl From<AccountsPath> for Path {
-    fn from(path: AccountsPath) -> Self {
-        format!("accounts/{}", path.0).try_into().unwrap() // safety - cannot fail as AccountsPath is correct-by-construction
+impl From<(Denom, u64)> for Coin {
+    fn from((denom, amount): (Denom, u64)) -> Self {
+        Self { denom, amount }
     }
 }
 
-/// The bank module
-pub struct Bank<S> {
-    /// Handle to store instance
-    /// The module is guaranteed exclusive access to all paths in the store key-space.
-    store: SharedStore<S>,
-    /// A typed-store for accounts
-    account_store: JsonStore<SharedStore<S>, AccountsPath, Balances>,
-}
-
-impl<S: ProvableStore + Default> Bank<S> {
-    pub fn new(store: SharedStore<S>) -> Self {
+impl From<&MsgCoin> for Coin {
+    fn from(coin: &MsgCoin) -> Self {
         Self {
-            store: store.clone(),
-            account_store: TypedStore::new(store),
+            denom: Denom(coin.denom.to_string()),
+            amount: coin.amount.to_string().parse().unwrap(),
         }
     }
 }
 
-impl<S: Store> Bank<S> {
+/// A mapping of currency denomination identifiers to balances.
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(transparent)]
+pub struct Balances(Vec<Coin>);
+
+#[derive(Clone)]
+struct BalancesPath(AccountId);
+
+impl From<BalancesPath> for Path {
+    fn from(path: BalancesPath) -> Self {
+        format!("balances/{}", path.0).try_into().unwrap() // safety - cannot fail as AccountsPath is correct-by-construction
+    }
+}
+
+pub trait BankReader {
+    type Address;
+    type Denom;
+    type Coin;
+    type Coins: IntoIterator<Item = Self::Coin>;
+
+    fn get_all_balances_at_height(&self, height: Height, address: Self::Address) -> Self::Coins;
+
+    fn get_all_balances(&self, address: Self::Address) -> Self::Coins {
+        self.get_all_balances_at_height(Height::Pending, address)
+    }
+}
+
+pub trait BankKeeper {
+    type Error;
+    type Address;
+    type Denom;
+    type Coin;
+    type Coins: IntoIterator<Item = Self::Coin>;
+
+    fn set_balances(
+        &mut self,
+        address: Self::Address,
+        coins: Self::Coins,
+    ) -> Result<(), Self::Error>;
+}
+
+pub struct BankBalanceReader<S> {
+    balance_store: JsonStore<SharedStore<S>, BalancesPath, Balances>,
+}
+
+impl<S: Store> BankReader for BankBalanceReader<S> {
+    type Address = AccountId;
+    type Denom = Denom;
+    type Coin = Coin;
+    type Coins = Vec<Coin>;
+
+    fn get_all_balances_at_height(&self, height: Height, address: Self::Address) -> Self::Coins {
+        self.balance_store
+            .get(height, &BalancesPath(address))
+            .map(|b| b.0)
+            .unwrap_or_default()
+    }
+}
+
+pub struct BankBalanceKeeper<S> {
+    balance_store: JsonStore<SharedStore<S>, BalancesPath, Balances>,
+}
+
+impl<S: Store> BankKeeper for BankBalanceKeeper<S> {
+    type Error = ();
+    type Address = AccountId;
+    type Denom = Denom;
+    type Coin = Coin;
+    type Coins = Vec<Self::Coin>;
+
+    fn set_balances(
+        &mut self,
+        address: Self::Address,
+        coins: Self::Coins,
+    ) -> Result<(), Self::Error> {
+        self.balance_store
+            .set(BalancesPath(address), Balances(coins))
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+}
+
+/// The bank module
+pub struct Bank<S, AR, AK> {
+    /// Handle to store instance
+    /// The module is guaranteed exclusive access to all paths in the store key-space.
+    store: SharedStore<S>,
+    balance_reader: BankBalanceReader<S>,
+    balance_keeper: BankBalanceKeeper<S>,
+    account_reader: AR,
+    account_keeper: AK,
+}
+
+impl<S: ProvableStore + Default, AR: AccountReader, AK: AccountKeeper> Bank<S, AR, AK> {
+    pub fn new(store: SharedStore<S>, account_reader: AR, account_keeper: AK) -> Self {
+        Self {
+            store: store.clone(),
+            balance_reader: BankBalanceReader {
+                balance_store: TypedStore::new(store.clone()),
+            },
+            balance_keeper: BankBalanceKeeper {
+                balance_store: TypedStore::new(store),
+            },
+            account_reader,
+            account_keeper,
+        }
+    }
+}
+
+impl<S: Store, AR: AccountReader, AK: AccountKeeper> Bank<S, AR, AK> {
     fn decode<T: Message + Default>(message: Any) -> Result<T, ModuleError> {
         if message.type_url != "/cosmos.bank.v1beta1.MsgSend" {
             return Err(ModuleError::not_handled());
@@ -92,64 +192,61 @@ impl<S: Store> Bank<S> {
     }
 }
 
-impl<S: ProvableStore> Module<S> for Bank<S> {
+impl<S: ProvableStore, AR: AccountReader + Send + Sync, AK: AccountKeeper + Send + Sync> Module<S>
+    for Bank<S, AR, AK>
+where
+    <AR as AccountReader>::Address: From<cosmrs::AccountId>,
+    <AK as AccountKeeper>::Account: From<AuthAccount>,
+{
     fn deliver(&mut self, message: Any) -> Result<Vec<Event>, ModuleError> {
         let message: MsgSend = Self::decode::<proto::cosmos::bank::v1beta1::MsgSend>(message)?
             .try_into()
             .map_err(|e| Error::msg_validation_failure(format!("{:?}", e)))?;
 
-        let amounts = message
-            .amount
-            .iter()
-            .map(|coin| {
-                let amt = coin.amount.to_string();
-                match u64::from_str(&amt) {
-                    Ok(amt) => Ok((amt, coin.denom.to_string())),
-                    Err(e) => Err(Error::invalid_amount(e)),
-                }
-            })
-            .collect::<Result<Vec<(u64, String)>, Error>>()?;
+        let _ = self
+            .account_reader
+            .get_account(message.from_address.clone().into())
+            .map_err(|_| Error::non_existent_account(message.from_address.clone()))?;
 
-        let src_path = AccountsPath(message.from_address.clone());
-        let mut src_balances: Balances = match self.account_store.get(Height::Pending, &src_path) {
-            Some(sb) => sb,
-            None => {
-                return Err(Error::non_existent_account(message.from_address).into());
+        // we allow transfers to non-existent destination accounts
+
+        let mut src_balances = self
+            .balance_reader
+            .get_all_balances(message.from_address.clone());
+        let mut dst_balances = self
+            .balance_reader
+            .get_all_balances(message.to_address.clone());
+
+        let amounts: Vec<Coin> = message.amount.iter().map(|amt| amt.into()).collect();
+        for Coin { denom, amount } in amounts {
+            let mut src_balance = src_balances
+                .iter_mut()
+                .find(|c| c.denom == denom)
+                .ok_or_else(Error::insufficient_source_funds)?;
+
+            if dst_balances.iter().any(|c| c.denom == denom) {
+                dst_balances.push(Coin {
+                    denom: denom.clone(),
+                    amount: 0u64,
+                });
             }
-        };
 
-        let dst_path = AccountsPath(message.to_address);
-        let mut dst_balances: Balances = self
-            .account_store
-            .get(Height::Pending, &dst_path)
-            .unwrap_or_default();
+            let mut dst_balance = dst_balances.iter_mut().find(|c| c.denom == denom).unwrap();
 
-        // TODO(hu55a1n1): extract account related code into the `auth` module
-        for (amount, denom) in amounts {
-            let mut src_balance = match src_balances.0.get(&denom) {
-                Some(b) if *b >= amount => *b,
-                _ => return Err(Error::insufficient_source_funds().into()),
-            };
-            let mut dst_balance = dst_balances
-                .0
-                .get(&denom)
-                .map(Clone::clone)
-                .unwrap_or(0_u64);
-            if dst_balance > u64::MAX - amount {
+            if dst_balance.amount > u64::MAX - amount {
                 return Err(Error::dest_fund_overflow().into());
             }
-            src_balance -= amount;
-            dst_balance += amount;
-            src_balances.0.insert(denom.to_owned(), src_balance);
-            dst_balances.0.insert(denom.to_owned(), dst_balance);
+
+            src_balance.amount -= amount;
+            dst_balance.amount += amount;
         }
 
         // Store the updated account balances
-        self.account_store
-            .set(src_path, src_balances)
+        self.balance_keeper
+            .set_balances(message.from_address, src_balances)
             .map_err(|e| Error::store(format!("{:?}", e)))?;
-        self.account_store
-            .set(dst_path, dst_balances)
+        self.balance_keeper
+            .set_balances(message.to_address, dst_balances)
             .map_err(|e| Error::store(format!("{:?}", e)))?;
 
         Ok(vec![])
@@ -159,13 +256,18 @@ impl<S: ProvableStore> Module<S> for Bank<S> {
         debug!("Initializing bank module");
 
         // safety - we panic on errors to prevent chain creation with invalid genesis config
-        let accounts: HashMap<String, Balances> = serde_json::from_value(app_state).unwrap();
-        for account in accounts {
-            trace!("Adding account ({}) => {:?}", account.0, account.1);
+        let accounts: HashMap<String, HashMap<Denom, u64>> =
+            serde_json::from_value(app_state).unwrap();
+        for (account, balances) in accounts {
+            trace!("Adding account ({}) => {:?}", account, balances);
 
-            let account_id = AccountId::from_str(&account.0).unwrap();
-            self.account_store
-                .set(AccountsPath(account_id), account.1)
+            let account_id = AccountId::from_str(&account).unwrap();
+            self.account_keeper
+                .set_account(AuthAccount::new(account_id.clone()).into())
+                .map_err(|_| "Failed to create account")
+                .unwrap();
+            self.balance_keeper
+                .set_balances(account_id, balances.into_iter().map(|b| b.into()).collect())
                 .unwrap();
         }
     }
@@ -187,16 +289,19 @@ impl<S: ProvableStore> Module<S> for Bank<S> {
 
         trace!("Attempting to get account ID: {}", account_id);
 
-        match self
-            .account_store
-            .get(height, &AccountsPath(account_id.clone()))
-        {
-            None => Err(Error::non_existent_account(account_id).into()),
-            Some(balance) => Ok(QueryResult {
-                data: JsonCodec::encode(&balance).unwrap().into_bytes(),
-                proof: None,
-            }),
-        }
+        let _ = self
+            .account_reader
+            .get_account(account_id.clone().into())
+            .map_err(|_| Error::non_existent_account(account_id.clone()))?;
+
+        let balance = self
+            .balance_reader
+            .get_all_balances_at_height(height, account_id);
+
+        Ok(QueryResult {
+            data: JsonCodec::encode(&balance).unwrap().into_bytes(),
+            proof: None,
+        })
     }
 
     fn commit(&mut self) -> Result<Vec<u8>, S::Error> {

--- a/src/app/modules/bank.rs
+++ b/src/app/modules/bank.rs
@@ -1,5 +1,5 @@
 use crate::app::modules::{Error as ModuleError, Module, QueryResult};
-use crate::app::store::{Codec, Height, JsonCodec, Path, Store, TypedStore};
+use crate::app::store::{Codec, Height, JsonCodec, JsonStore, Path, Store};
 
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -69,14 +69,14 @@ pub struct Bank<S> {
     /// The module is guaranteed exclusive access to all paths in the store key-space.
     store: S,
     /// A typed-store for accounts
-    account_store: TypedStore<S, JsonCodec<Balances>, AccountsPath, Balances>,
+    account_store: JsonStore<S, AccountsPath, Balances>,
 }
 
 impl<S: Store> Bank<S> {
     pub fn new(store: S) -> Self {
         Self {
             store: store.clone(),
-            account_store: TypedStore::new(store),
+            account_store: JsonStore::new(store),
         }
     }
 

--- a/src/app/modules/bank.rs
+++ b/src/app/modules/bank.rs
@@ -1,6 +1,6 @@
 use crate::app::modules::{Error as ModuleError, Module, QueryResult};
 use crate::app::store::{
-    Codec, Height, JsonCodec, JsonStore, Path, ProvableStore, SharedStore, Store, SubStore,
+    Codec, Height, JsonCodec, JsonStore, Path, ProvableStore, SharedStore, Store, TypedStore,
 };
 
 use std::collections::HashMap;
@@ -74,11 +74,11 @@ pub struct Bank<S> {
     account_store: JsonStore<SharedStore<S>, AccountsPath, Balances>,
 }
 
-impl<S: ProvableStore + Default> Bank<SubStore<S>> {
-    pub fn new(store: SharedStore<SubStore<S>>) -> Self {
+impl<S: ProvableStore + Default> Bank<S> {
+    pub fn new(store: SharedStore<S>) -> Self {
         Self {
             store: store.clone(),
-            account_store: SubStore::typed_store(store),
+            account_store: TypedStore::new(store),
         }
     }
 }

--- a/src/app/modules/ibc.rs
+++ b/src/app/modules/ibc.rs
@@ -1,5 +1,5 @@
 use crate::app::modules::{Error as ModuleError, Identifiable, Module, QueryResult};
-use crate::app::store::{Height, Path, ProvableStore, Store};
+use crate::app::store::{Height, Path, ProvableStore, SharedStore, Store};
 use crate::prostgen::ibc::core::client::v1::{
     query_server::Query as ClientQuery, ConsensusStateWithHeight, Height as RawHeight,
     QueryClientParamsRequest, QueryClientParamsResponse, QueryClientStateRequest,
@@ -85,7 +85,7 @@ impl From<IbcPath> for Path {
 pub struct Ibc<S> {
     /// Handle to store instance.
     /// The module is guaranteed exclusive access to all paths in the store key-space.
-    store: S,
+    store: SharedStore<S>,
     /// Counter for clients
     client_counter: u64,
     /// Counter for connections
@@ -95,7 +95,7 @@ pub struct Ibc<S> {
 impl<S: ProvableStore> Ibc<S> {
     pub fn new(store: S) -> Self {
         Self {
-            store,
+            store: SharedStore::new(store),
             client_counter: 0,
             conn_counter: 0,
         }
@@ -654,7 +654,7 @@ impl<S: ProvableStore> Module<S> for Ibc<S> {
         self.store.commit()
     }
 
-    fn store(&self) -> S {
+    fn store(&self) -> SharedStore<S> {
         self.store.clone()
     }
 }

--- a/src/app/modules/ibc.rs
+++ b/src/app/modules/ibc.rs
@@ -1,5 +1,5 @@
 use crate::app::modules::{Error as ModuleError, Identifiable, Module, QueryResult};
-use crate::app::store::{Height, JsonStore, Path, ProvableStore, SharedStore, Store, SubStore};
+use crate::app::store::{Height, JsonStore, Path, ProvableStore, SharedStore, Store, TypedStore};
 use crate::prostgen::ibc::core::client::v1::{
     query_server::Query as ClientQuery, ConsensusStateWithHeight, Height as RawHeight,
     QueryClientParamsRequest, QueryClientParamsResponse, QueryClientStateRequest,
@@ -98,15 +98,15 @@ pub struct Ibc<S> {
     connection_end_store: JsonStore<SharedStore<S>, IbcPath, ConnectionEnd>,
 }
 
-impl<S: ProvableStore + Default> Ibc<SubStore<S>> {
-    pub fn new(store: SharedStore<SubStore<S>>) -> Self {
+impl<S: ProvableStore + Default> Ibc<S> {
+    pub fn new(store: SharedStore<S>) -> Self {
         Self {
             store: store.clone(),
             client_counter: 0,
             conn_counter: 0,
-            client_type_store: SubStore::typed_store(store.clone()),
-            client_state_store: SubStore::typed_store(store.clone()),
-            connection_end_store: SubStore::typed_store(store),
+            client_type_store: TypedStore::new(store.clone()),
+            client_state_store: TypedStore::new(store.clone()),
+            connection_end_store: TypedStore::new(store),
         }
     }
 }

--- a/src/app/modules/ibc.rs
+++ b/src/app/modules/ibc.rs
@@ -1,5 +1,7 @@
 use crate::app::modules::{Error as ModuleError, Identifiable, Module, QueryResult};
-use crate::app::store::{Height, JsonStore, Path, ProvableStore, SharedStore, Store, TypedStore};
+use crate::app::store::{
+    Height, JsonStore, Path, ProtobufStore, ProvableStore, SharedStore, Store, TypedStore,
+};
 use crate::prostgen::ibc::core::client::v1::{
     query_server::Query as ClientQuery, ConsensusStateWithHeight, Height as RawHeight,
     QueryClientParamsRequest, QueryClientParamsResponse, QueryClientStateRequest,
@@ -93,9 +95,10 @@ pub struct Ibc<S> {
     /// A typed-store for ClientType
     client_type_store: JsonStore<SharedStore<S>, IbcPath, ClientType>,
     /// A typed-store for AnyClientState
-    client_state_store: JsonStore<SharedStore<S>, IbcPath, AnyClientState>,
+    client_state_store: ProtobufStore<SharedStore<S>, IbcPath, AnyClientState, Any>,
     /// A typed-store for ConnectionEnd
-    connection_end_store: JsonStore<SharedStore<S>, IbcPath, ConnectionEnd>,
+    connection_end_store:
+        ProtobufStore<SharedStore<S>, IbcPath, ConnectionEnd, IbcRawConnectionEnd>,
 }
 
 impl<S: ProvableStore + Default> Ibc<S> {

--- a/src/app/modules/mod.rs
+++ b/src/app/modules/mod.rs
@@ -3,8 +3,10 @@ mod bank;
 mod ibc;
 mod staking;
 
+pub(crate) use self::auth::Auth;
 pub(crate) use self::bank::Bank;
 pub(crate) use self::ibc::Ibc;
+pub(crate) use self::staking::Staking;
 
 use crate::app::store::{self, Height, Path, SharedStore, Store};
 
@@ -115,6 +117,30 @@ pub(crate) mod prefix {
 
         fn identifier(&self) -> Self::Identifier {
             "ibc".to_owned().try_into().unwrap()
+        }
+    }
+
+    /// Auth module prefix
+    #[derive(Clone)]
+    pub(crate) struct Auth;
+
+    impl Identifiable for Auth {
+        type Identifier = store::Identifier;
+
+        fn identifier(&self) -> Self::Identifier {
+            "auth".to_owned().try_into().unwrap()
+        }
+    }
+
+    /// Staking module prefix
+    #[derive(Clone)]
+    pub(crate) struct Staking;
+
+    impl Identifiable for Staking {
+        type Identifier = store::Identifier;
+
+        fn identifier(&self) -> Self::Identifier {
+            "staking".to_owned().try_into().unwrap()
         }
     }
 }

--- a/src/app/modules/mod.rs
+++ b/src/app/modules/mod.rs
@@ -5,7 +5,7 @@ mod staking;
 pub(crate) use self::bank::Bank;
 pub(crate) use self::ibc::Ibc;
 
-use crate::app::store::{self, Height, Path, Store};
+use crate::app::store::{self, Height, Path, SharedStore, Store};
 
 use flex_error::{define_error, TraceError};
 use prost_types::Any;
@@ -30,7 +30,7 @@ define_error! {
 }
 
 /// Module trait
-pub(crate) trait Module<S: Store> {
+pub(crate) trait Module<S: Store>: Send + Sync {
     /// Similar to [ABCI CheckTx method](https://docs.tendermint.com/master/spec/abci/abci.html#checktx)
     /// > CheckTx need not execute the transaction in full, but rather a light-weight yet
     /// > stateful validation, like checking signatures and account balances, but not running
@@ -71,7 +71,7 @@ pub(crate) trait Module<S: Store> {
 
     fn commit(&mut self) -> Result<Vec<u8>, S::Error>;
 
-    fn store(&self) -> S;
+    fn store(&self) -> SharedStore<S>;
 }
 
 pub struct QueryResult {

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -233,9 +233,8 @@ impl<S: Default + ProvableStore> SubStore<S> {
     pub(crate) fn typed_store<C, K, V>(&self) -> TypedStore<Self, C, K, V> {
         TypedStore::new(self.clone())
     }
-}
 
-impl<S: Default + ProvableStore> SubStore<S> {
+    #[inline]
     fn update_main_store_commitment(&mut self) -> Result<Option<Vec<u8>>, S::Error> {
         self.main_store
             .set(Path::from(self.prefix.clone()), self.sub_store.root_hash())

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -173,7 +173,7 @@ pub trait Store: Send + Sync + Clone {
     fn reset(&mut self) {}
 
     /// Prune historic blocks upto specified `height`
-    fn prune(&self, height: RawHeight) -> Result<RawHeight, Self::Error> {
+    fn prune(&mut self, height: RawHeight) -> Result<RawHeight, Self::Error> {
         Ok(height)
     }
 

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -221,8 +221,14 @@ impl<S: Default + ProvableStore> SubStore<S> {
         Ok(sub_store)
     }
 
+    #[inline]
     pub(crate) fn prefix(&self) -> Identifier {
         self.prefix.clone()
+    }
+
+    #[inline]
+    pub(crate) fn typed_store<C, K, V>(&self) -> TypedStore<Self, C, K, V> {
+        TypedStore::new(self.clone())
     }
 }
 
@@ -518,7 +524,7 @@ pub(crate) struct TypedStore<S, C, K, V> {
 }
 
 impl<S: Store, C, K, V> TypedStore<S, C, K, V> {
-    pub(crate) fn new(store: S) -> Self {
+    fn new(store: S) -> Self {
         Self {
             store,
             _codec: PhantomData,

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -21,9 +21,6 @@ use tracing::trace;
 /// A `TypedStore` that uses the `JsonCodec`
 pub(crate) type JsonStore<S, K, V> = TypedStore<S, JsonCodec<V>, K, V>;
 
-/// A `TypedStore` that uses the `ProtobufCodec`
-pub(crate) type ProtobufStore<S, K, V> = TypedStore<S, ProtobufCodec<V>, K, V>;
-
 /// A newtype representing a valid ICS024 identifier.
 /// Implements `Deref<Target=String>`.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
@@ -516,23 +513,6 @@ impl<'a, T: Serialize + DeserializeOwned> Codec<'a> for JsonCodec<T> {
     fn decode(bytes: &'a [u8]) -> Option<Self::Type> {
         let json_string = String::from_utf8(bytes.to_vec()).ok()?;
         serde_json::from_str(&json_string).ok()
-    }
-}
-
-/// A ProtoBuf codec that uses protobuf for serde
-#[derive(Clone)]
-pub(crate) struct ProtobufCodec<T>(PhantomData<T>);
-
-impl<'a, T: prost::Message + Default> Codec<'a> for ProtobufCodec<T> {
-    type Type = T;
-    type Encoded = Vec<u8>;
-
-    fn encode(d: &'a Self::Type) -> Option<Self::Encoded> {
-        Some(prost::Message::encode_to_vec(d))
-    }
-
-    fn decode(bytes: &'a [u8]) -> Option<Self::Type> {
-        prost::Message::decode(bytes).ok()
     }
 }
 

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -492,7 +492,7 @@ pub(crate) trait Codec<'a> {
     type Type;
     type Encoded: AsRef<[u8]>;
 
-    fn encode(d: Self::Type) -> Option<Self::Encoded>;
+    fn encode(d: &'a Self::Type) -> Option<Self::Encoded>;
 
     fn decode(bytes: &'a [u8]) -> Option<Self::Type>;
 }
@@ -504,8 +504,8 @@ impl<'a, T: Serialize + DeserializeOwned> Codec<'a> for JsonCodec<T> {
     type Type = T;
     type Encoded = String;
 
-    fn encode(d: Self::Type) -> Option<Self::Encoded> {
-        serde_json::to_string(&d).ok()
+    fn encode(d: &'a Self::Type) -> Option<Self::Encoded> {
+        serde_json::to_string(d).ok()
     }
 
     fn decode(bytes: &'a [u8]) -> Option<Self::Type> {
@@ -541,7 +541,7 @@ where
     #[inline]
     pub(crate) fn set(&mut self, path: K, value: V) -> Result<Option<V>, S::Error> {
         self.store
-            .set(path.into(), C::encode(value).unwrap().as_ref().to_vec())
+            .set(path.into(), C::encode(&value).unwrap().as_ref().to_vec())
             .map(|prev_val| prev_val.and_then(|v| C::decode(&v)))
     }
 

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -489,28 +489,26 @@ impl<S: ProvableStore> ProvableStore for RevertibleStore<S> {
 
 /// A trait that defines how types are decoded/encoded.
 pub(crate) trait Codec<'a> {
-    type In;
+    type Type;
     type Encoded: AsRef<[u8]>;
-    type Out;
 
-    fn encode(d: Self::In) -> Option<Self::Encoded>;
+    fn encode(d: Self::Type) -> Option<Self::Encoded>;
 
-    fn decode(bytes: &'a [u8]) -> Option<Self::Out>;
+    fn decode(bytes: &'a [u8]) -> Option<Self::Type>;
 }
 
 /// A JSON codec that uses `serde_json` to encode/decode as a JSON string
 pub(crate) struct JsonCodec<T>(PhantomData<T>);
 
 impl<'a, T: Serialize + DeserializeOwned> Codec<'a> for JsonCodec<T> {
-    type In = T;
+    type Type = T;
     type Encoded = String;
-    type Out = T;
 
-    fn encode(d: Self::In) -> Option<Self::Encoded> {
+    fn encode(d: Self::Type) -> Option<Self::Encoded> {
         serde_json::to_string(&d).ok()
     }
 
-    fn decode(bytes: &'a [u8]) -> Option<Self::Out> {
+    fn decode(bytes: &'a [u8]) -> Option<Self::Type> {
         let json_string = String::from_utf8(bytes.to_vec()).ok()?;
         serde_json::from_str(&json_string).ok()
     }
@@ -537,7 +535,7 @@ impl<S: Store, C, K, V> TypedStore<S, C, K, V> {
 impl<S, C, K, V> TypedStore<S, C, K, V>
 where
     S: Store,
-    for<'a> C: Codec<'a, In = V, Out = V>,
+    for<'a> C: Codec<'a, Type = V>,
     K: Into<Path> + Clone,
 {
     #[inline]

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -230,8 +230,10 @@ impl<S: Default + ProvableStore> SubStore<S> {
     }
 
     #[inline]
-    pub(crate) fn typed_store<C, K, V>(&self) -> TypedStore<Self, C, K, V> {
-        TypedStore::new(self.clone())
+    pub(crate) fn typed_store<C, K, V>(
+        store: SharedStore<SubStore<S>>,
+    ) -> TypedStore<SharedStore<SubStore<S>>, C, K, V> {
+        TypedStore::new(store)
     }
 
     #[inline]
@@ -542,7 +544,7 @@ pub(crate) struct TypedStore<S, C, K, V> {
     _value: PhantomData<V>,
 }
 
-impl<S: Store, C, K, V> TypedStore<S, C, K, V> {
+impl<S, C, K, V> TypedStore<S, C, K, V> {
     fn new(store: S) -> Self {
         Self {
             store,

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -18,6 +18,9 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::marker::PhantomData;
 use tracing::trace;
 
+/// A `TypedStore` that uses the `JsonCodec`
+pub(crate) type JsonStore<S, K, V> = TypedStore<S, JsonCodec<V>, K, V>;
+
 /// A newtype representing a valid ICS024 identifier.
 /// Implements `Deref<Target=String>`.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]

--- a/src/app/store/mod.rs
+++ b/src/app/store/mod.rs
@@ -21,6 +21,9 @@ use tracing::trace;
 /// A `TypedStore` that uses the `JsonCodec`
 pub(crate) type JsonStore<S, K, V> = TypedStore<S, JsonCodec<V>, K, V>;
 
+/// A `TypedStore` that uses the `ProtobufCodec`
+pub(crate) type ProtobufStore<S, K, V> = TypedStore<S, ProtobufCodec<V>, K, V>;
+
 /// A newtype representing a valid ICS024 identifier.
 /// Implements `Deref<Target=String>`.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
@@ -498,6 +501,7 @@ pub(crate) trait Codec<'a> {
 }
 
 /// A JSON codec that uses `serde_json` to encode/decode as a JSON string
+#[derive(Clone)]
 pub(crate) struct JsonCodec<T>(PhantomData<T>);
 
 impl<'a, T: Serialize + DeserializeOwned> Codec<'a> for JsonCodec<T> {
@@ -514,6 +518,24 @@ impl<'a, T: Serialize + DeserializeOwned> Codec<'a> for JsonCodec<T> {
     }
 }
 
+/// A ProtoBuf codec that uses protobuf for serde
+#[derive(Clone)]
+pub(crate) struct ProtobufCodec<T>(PhantomData<T>);
+
+impl<'a, T: prost::Message + Default> Codec<'a> for ProtobufCodec<T> {
+    type Type = T;
+    type Encoded = Vec<u8>;
+
+    fn encode(d: &'a Self::Type) -> Option<Self::Encoded> {
+        Some(prost::Message::encode_to_vec(d))
+    }
+
+    fn decode(bytes: &'a [u8]) -> Option<Self::Type> {
+        prost::Message::decode(bytes).ok()
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct TypedStore<S, C, K, V> {
     store: S,
     _codec: PhantomData<C>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn grpc_serve<S: Default + ProvableStore + 'static>(
 ) {
     let addr = format!("{}:{}", host, port).parse().unwrap();
 
-    let ibc = Ibc::new(app.get_store(prefix::Ibc {}.identifier()).unwrap());
+    let ibc = Ibc::new(app.get_store(&prefix::Ibc {}.identifier()).unwrap());
 
     // TODO(hu55a1n1): implement these services for `auth` and `staking` modules
     Server::builder()


### PR DESCRIPTION
Resolves #40 
This PR defines a `TypedStore` construct that allows users to create stores for a particular path, value and codec. For e.g. ->
```rust
pub struct Bank<S> {
    store: S,
    account_store: JsonStore<S, AccountsPath, Balances>,   // <-----------
}
```
The `account_store` above uses the `Bank` module's `SubStore` and is able to store values of type `Balances` at the `AccountsPath` (i.e. `bank/accounts/<address>`). Furthermore it uses the `JsonCodec` (which (de)serializes to a JSON encoded string) to serialize the value for storage. 
It will also be possible to restrict users from creating multiple `TypedStore`s for the same `Path`.