### PR TITLE
Update ibc-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.39.0"
-source = "git+https://github.com/cosmos/ibc-rs/?rev=9e79fa6#9e79fa6debfe6e3a967907acfc33114fa44d6c93"
+source = "git+https://github.com/cosmos/ibc-rs/?rev=7da7598#7da7598a35203fb29788c0ca321be3354360d948"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,8 +922,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0370ed0e8916ffc7199ca1d9fc6bdd8627fd460d743f31fa03e82ac4b9d7fd0"
+source = "git+https://github.com/cosmos/ibc-rs/?rev=9e79fa6#9e79fa6debfe6e3a967907acfc33114fa44d6c93"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 cosmrs = "0.11.0"
 displaydoc = { version = "0.2", default-features = false }
 ed25519 = { version = "2.1.0", default-features = false }
-ibc = "0.39.0"
+ibc = { git = "https://github.com/cosmos/ibc-rs/", rev = "9e79fa6"}
 ibc-proto = { version = "=0.29.0", default-features = false, features = ["server"] }
 ics23 = { version = "=0.9.0", default-features = false }
 primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 cosmrs = "0.11.0"
 displaydoc = { version = "0.2", default-features = false }
 ed25519 = { version = "2.1.0", default-features = false }
-ibc = { git = "https://github.com/cosmos/ibc-rs/", rev = "9e79fa6"}
+ibc = { git = "https://github.com/cosmos/ibc-rs/", rev = "7da7598"}
 ibc-proto = { version = "=0.29.0", default-features = false, features = ["server"] }
 ics23 = { version = "=0.9.0", default-features = false }
 primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }

--- a/src/helper/error.rs
+++ b/src/helper/error.rs
@@ -1,6 +1,6 @@
 use crate::error::Error as AppError;
 use displaydoc::Display;
-use ibc::core::ics24_host::error::ValidationError;
+use ibc::core::ics24_host::identifier::IdentifierError;
 use std::str::Utf8Error;
 
 #[derive(Debug, Display)]
@@ -8,7 +8,7 @@ pub enum Error {
     /// '{identifier}' is not a valid identifier: `{error}`
     InvalidIdentifier {
         identifier: String,
-        error: ValidationError,
+        error: IdentifierError,
     },
     /// path isn't a valid string: `{error}`
     MalformedPathString { error: Utf8Error },

--- a/src/modules/ibc/error.rs
+++ b/src/modules/ibc/error.rs
@@ -1,5 +1,6 @@
 pub use crate::error::Error as AppError;
-pub use ibc::core::ics26_routing::error::RouterError;
+use ibc::core::RouterError;
+
 pub type Error = RouterError;
 
 impl From<Error> for AppError {

--- a/src/modules/ibc/impls.rs
+++ b/src/modules/ibc/impls.rs
@@ -44,7 +44,8 @@ use ibc::{
         router::{Module as IbcModule, Router as ContextRouter},
         ContextError, ExecutionContext, MsgEnvelope, ValidationContext,
     },
-    Height as IbcHeight, hosts::tendermint::ABCI_QUERY_PATH_FOR_IBC,
+    hosts::tendermint::ABCI_QUERY_PATH_FOR_IBC,
+    Height as IbcHeight,
 };
 use ibc::{
     applications::transfer::{send_transfer, MODULE_ID_STR as IBC_TRANSFER_MODULE_ID},

--- a/src/modules/ibc/impls.rs
+++ b/src/modules/ibc/impls.rs
@@ -13,18 +13,12 @@ use crate::{
 };
 use cosmrs::AccountId;
 use ibc::{
-    applications::transfer::MODULE_ID_STR as IBC_TRANSFER_MODULE_ID,
-    core::{ics24_host::identifier::PortId, ics26_routing::context::ModuleId},
-    signer::Signer,
-};
-use ibc::{
-    applications::transfer::{msgs::transfer::MsgTransfer, relay::send_transfer::send_transfer},
+    applications::transfer::msgs::transfer::MsgTransfer,
     clients::ics07_tendermint::{
         client_state::ClientState as TmClientState,
         consensus_state::ConsensusState as TmConsensusState,
     },
     core::{
-        context::{ExecutionContext, Router as ContextRouter, ValidationContext},
         ics02_client::{
             client_state::ClientState, consensus_state::ConsensusState, error::ClientError,
         },
@@ -35,27 +29,30 @@ use ibc::{
         ics04_channel::{
             channel::ChannelEnd,
             commitment::{AcknowledgementCommitment, PacketCommitment},
-            context::calculate_block_delay,
             error::{ChannelError, PacketError},
             packet::{Receipt, Sequence},
         },
-        ics05_port::error::PortError,
         ics23_commitment::commitment::{CommitmentPrefix, CommitmentRoot},
         ics24_host::{
             identifier::{ClientId, ConnectionId},
             path::{
                 AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath,
-                ClientStatePath, CommitmentPath, ConnectionPath, ReceiptPath, SeqAckPath,
-                SeqRecvPath, SeqSendPath,
+                ClientStatePath, CommitmentPath, ConnectionPath, Path as IbcPath, ReceiptPath,
+                SeqAckPath, SeqRecvPath, SeqSendPath,
             },
-            Path as IbcPath, IBC_QUERY_PATH,
         },
-        ics26_routing::{context::Module as IbcModule, msgs::MsgEnvelope},
-        ContextError,
+        router::{Module as IbcModule, Router as ContextRouter},
+        ContextError, ExecutionContext, MsgEnvelope, ValidationContext,
     },
-    events::IbcEvent,
-    timestamp::Timestamp,
-    Height as IbcHeight,
+    Height as IbcHeight, hosts::tendermint::ABCI_QUERY_PATH_FOR_IBC,
+};
+use ibc::{
+    applications::transfer::{send_transfer, MODULE_ID_STR as IBC_TRANSFER_MODULE_ID},
+    core::{
+        events::IbcEvent, ics04_channel::error::PortError, ics24_host::identifier::PortId,
+        router::ModuleId, timestamp::Timestamp,
+    },
+    Signer,
 };
 use ibc_proto::{
     google::protobuf::Any,
@@ -81,7 +78,7 @@ use tendermint_proto::{
 };
 use tracing::debug;
 
-use ibc::core::handler::dispatch;
+use ibc::core::dispatch;
 
 /// The Ibc module
 /// Implements all ibc-rs `Reader`s and `Keeper`s
@@ -147,7 +144,7 @@ where
     pub fn new(store: SharedStore<S>, bank_keeper: BankBalanceKeeper<S>) -> Self {
         let mut port_to_module_map = BTreeMap::default();
 
-        let transfer_module_id: ModuleId = IBC_TRANSFER_MODULE_ID.parse().unwrap();
+        let transfer_module_id: ModuleId = ModuleId::new(IBC_TRANSFER_MODULE_ID.to_string());
         let transfer_module = IbcTransferModule::new(store.clone(), bank_keeper);
 
         let router = IbcRouter::new(transfer_module);
@@ -256,7 +253,7 @@ where
         prove: bool,
     ) -> Result<QueryResult, AppError> {
         let path = path.ok_or(AppError::NotHandled)?;
-        if path.to_string() != IBC_QUERY_PATH {
+        if path.to_string() != ABCI_QUERY_PATH_FOR_IBC {
             return Err(AppError::NotHandled);
         }
 
@@ -669,15 +666,6 @@ where
     /// Returns the maximum expected time per block
     fn max_expected_time_per_block(&self) -> Duration {
         Duration::from_secs(8)
-    }
-
-    /// Calculates the block delay period using the connection's delay period and the maximum
-    /// expected time per block.
-    fn block_delay(&self, delay_period_time: &Duration) -> u64 {
-        calculate_block_delay(
-            delay_period_time,
-            &<Self as ValidationContext>::max_expected_time_per_block(self),
-        )
     }
 
     fn validate_message_signer(&self, _signer: &Signer) -> Result<(), ContextError> {

--- a/src/modules/ibc/router.rs
+++ b/src/modules/ibc/router.rs
@@ -2,7 +2,7 @@ use std::{borrow::Borrow, fmt::Debug, sync::Arc};
 
 use ibc::{
     applications::transfer::MODULE_ID_STR as IBC_TRANSFER_MODULE_ID,
-    core::ics26_routing::context::{Module as IbcModule, ModuleId},
+    core::router::{Module as IbcModule, ModuleId},
 };
 
 use crate::{

--- a/src/modules/ibc/service.rs
+++ b/src/modules/ibc/service.rs
@@ -24,9 +24,8 @@ use ibc::{
             identifier::{ChannelId, ConnectionId},
             path::{
                 AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath,
-                ClientStatePath, CommitmentPath, ConnectionPath, ReceiptPath,
+                ClientStatePath, CommitmentPath, ConnectionPath, Path as IbcPath, ReceiptPath,
             },
-            Path as IbcPath,
         },
     },
 };

--- a/src/modules/ibc/transfer.rs
+++ b/src/modules/ibc/transfer.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use core::fmt::Debug;
 use cosmrs::AccountId;
-use ibc::{core::{ics24_host::identifier::PortId, events::IbcEvent, router::ModuleExtras, ics04_channel::packet::Acknowledgement}, Signer};
 use ibc::{applications::transfer::VERSION, core::ics24_host::path::SeqSendPath};
 use ibc::{
     applications::transfer::{
@@ -50,6 +49,13 @@ use ibc::{
         ContextError,
     },
     Height as IbcHeight,
+};
+use ibc::{
+    core::{
+        events::IbcEvent, ics04_channel::packet::Acknowledgement, ics24_host::identifier::PortId,
+        router::ModuleExtras,
+    },
+    Signer,
 };
 use ibc_proto::{
     google::protobuf::Any,

--- a/src/modules/ibc/transfer.rs
+++ b/src/modules/ibc/transfer.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use core::fmt::Debug;
 use cosmrs::AccountId;
-use ibc::core::ics24_host::identifier::PortId;
+use ibc::{core::{ics24_host::identifier::PortId, events::IbcEvent, router::ModuleExtras, ics04_channel::packet::Acknowledgement}, Signer};
 use ibc::{applications::transfer::VERSION, core::ics24_host::path::SeqSendPath};
 use ibc::{
     applications::transfer::{
@@ -36,8 +36,6 @@ use ibc::{
             commitment::PacketCommitment,
             context::{SendPacketExecutionContext, SendPacketValidationContext},
             error::{ChannelError, PacketError},
-            handler::ModuleExtras,
-            msgs::acknowledgement::Acknowledgement,
             packet::{Packet, Sequence},
             Version as ChannelVersion,
         },
@@ -48,11 +46,9 @@ use ibc::{
                 ConnectionPath,
             },
         },
-        ics26_routing::context::Module as IbcModule,
+        router::Module as IbcModule,
         ContextError,
     },
-    events::IbcEvent,
-    signer::Signer,
     Height as IbcHeight,
 };
 use ibc_proto::{


### PR DESCRIPTION
Depends on a small hotfix: https://github.com/cosmos/ibc-rs/pull/660

I realized with this change that we were re-implementing the `Identifier` and `Path` types in basecoin. `Identifier` is used both for module IDs and identifiers as part of a `Path`.

This is wrong; basecoin should use the `Path` defined in ibc-rs, and `ModuleId` in ibc-rs as well for module ids. Turns out the custom `Path` type is pretty ingrained in basecoin-rs right now (part of our store, etc); we should fix it properly in another PR (low priority). For now, I just removed the identifier validation.