### PR TITLE
fix cargo doc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,3 +71,23 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -Dwarnings -Drust-2018-idioms
+
+  cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc

--- a/src/modules/ibc/impls.rs
+++ b/src/modules/ibc/impls.rs
@@ -626,7 +626,7 @@ where
         Ok(ack)
     }
 
-    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`IbcHeight`]
     fn client_update_time(
         &self,
         client_id: &ClientId,
@@ -643,7 +643,7 @@ where
         Ok(processed_timestamp)
     }
 
-    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`IbcHeight`]
     fn client_update_height(
         &self,
         client_id: &ClientId,


### PR DESCRIPTION
`cargo doc` was failing because of a typo. This PR

1. fixes the typo.
2. checks `cargo doc` on CI