### PR TITLE
Track ibc-rs PR 790

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.7",
- "tendermint",
+ "tendermint 0.33.0",
  "tendermint-abci",
- "tendermint-proto",
+ "tendermint-proto 0.33.0",
  "tendermint-rpc",
  "tokio",
  "toml 0.7.6",
@@ -417,7 +417,7 @@ checksum = "73c9d2043a9e617b0d602fbc0a0ecd621568edbf3a9774890a6d562389bd8e1c"
 dependencies = [
  "prost",
  "prost-types",
- "tendermint-proto",
+ "tendermint-proto 0.32.2",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.32.2",
  "thiserror",
 ]
 
@@ -1083,8 +1083,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.44.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=c8c327e#c8c327e0b4103689a7f5b1bc6d1bf62d965c3273"
+version = "0.44.1"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=6ffe8ce#6ffe8ce26f40b029e176d8fe92dde13467fb3735"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1101,9 +1101,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.33.0",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.33.0",
  "time",
  "tracing",
  "uint",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.3.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=c8c327e#c8c327e0b4103689a7f5b1bc6d1bf62d965c3273"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=6ffe8ce#6ffe8ce26f40b029e176d8fe92dde13467fb3735"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.32.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c352715b36685c2543556a77091fb16af5d26257d5ce9c28e6756c1ccd71aa"
+checksum = "f6e8625e1aa28e4da4a33505c6469747a9201f14ccd9012e2481313dfbbf9e2f"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -1133,20 +1133,20 @@ dependencies = [
  "prost",
  "serde",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.33.0",
  "tonic",
 ]
 
 [[package]]
 name = "ics23"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9e8f569c5cc88e08b8d076dc207e0748aa1f52d4b84910ec919c8f2bed6ea7"
+checksum = "442d4bab37956e76f739c864f246c825d87c0bb7f9afa65660c57833c91bf6d4"
 dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "pbjson",
+ "informalsystems-pbjson",
  "prost",
  "ripemd",
  "serde",
@@ -1223,6 +1223,16 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eecd90f87bea412eac91c6ef94f6b1e390128290898cbe14f2b926787ae1fb"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -1506,16 +1516,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbjson"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
-dependencies = [
- "base64 0.13.1",
- "serde",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -2292,48 +2292,77 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.32.2",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d550db02d6bec4ebcbbebc4301ec22181bc489c37fb3f167e64b14c1be8321"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.7",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.33.0",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-abci"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5b683eb1beaa53a83a38addadb6bfbbd5efd70dfd5b1cc65cbf031a490163"
+checksum = "d737243f9b78ffdb750ca49b2bd45a794445cf364f5d6ed2e1e4bf4474b98a00"
 dependencies = [
  "bytes",
  "flex-error",
  "prost",
- "tendermint-proto",
+ "tendermint-proto 0.33.0",
  "tracing",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a72dbbea6dde12045d261f2c70c0de039125675e8a026c8d5ad34522756372"
+checksum = "36a787b139f314c92756becbcae855bef6772227d97d8ecee948ad90327fe6e7"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.33.0",
  "toml 0.5.11",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9875dce5c1b08201152eb0860f8fb1dce96c53e37532c310ffc4956d20f90def"
+checksum = "6bc1e4e3dd6f65cfa7979cf721b5afa1d79d32c4a2fe5fddb6416a98638634a9"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint",
+ "tendermint 0.33.0",
  "time",
 ]
 
@@ -2356,10 +2385,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-rpc"
-version = "0.32.2"
+name = "tendermint-proto"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d83a130537fc4a98c3c9eb6899ebe857fea4860400a61675bfb5f0b35129"
+checksum = "1834fa2eb884ba69b9c0eea55f0178270bed421217596ca4e54c19ef75dcb660"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f8ff62948110e58d6df12c3bb73a00e74553384255d6413deed4c21d7480bf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2378,9 +2425,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.33.0",
  "tendermint-config",
- "tendermint-proto",
+ "tendermint-proto 0.33.0",
  "thiserror",
  "time",
  "tokio",
@@ -2670,16 +2717,16 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1ae4967b2fa1d153c226dd9ca5d42b36749a35c6b57f0fe03e342390664d82"
+checksum = "42c629f4e6844d9c506d4b3b7894821015c72c818fc4e7e66275d34e5e0b43a2"
 dependencies = [
  "bytes",
  "futures",
  "pin-project",
  "prost",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.33.0",
+ "tendermint-proto 0.33.0",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,14 @@ default-run = "basecoin"
 
 
 [features]
-default = []
-tower-abci = ["dep:tower-abci", "dep:tower"]
+default = ["v0_37"]
+
+# Makes the application compatible with CometBFT v0.37
+v0_37 = ["dep:tower-abci", "dep:tower"] 
+
+# Makes the application compatible with CometBFT v0.38
+# (WIP) methods are not yet implemented
+v0_38 = ["dep:tendermint-abci"]
 
 [dependencies]
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
@@ -26,8 +32,8 @@ cosmrs = "0.14.0"
 displaydoc = { version = "0.2", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 ed25519 = { version = "2.1.0", default-features = false }
-ibc = { git = "https://github.com/cosmos/ibc-rs.git", rev= "c8c327e" }
-ibc-proto = { version = "0.32.1", default-features = false, features = ["server", "proto-descriptor"] }
+ibc = { git = "https://github.com/cosmos/ibc-rs.git", rev= "6ffe8ce" }
+ibc-proto = { version = "0.34.0", default-features = false, features = ["server", "proto-descriptor", "serde"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
 prost = { version = "0.11.6", default-features = false }
@@ -35,18 +41,17 @@ serde = "1.0"
 serde_derive = { version = "1.0.104", default-features = false }
 serde_json = "1.0"
 sha2 = "0.10.2"
-tendermint = "0.32.0"
-tendermint-abci = "0.32.0"
-tendermint-proto = "0.32.0"
-tendermint-rpc = {version = "0.32.0", features = ["http-client"] }
+tendermint = "0.33.0"
+tendermint-abci = { version = "0.33.0", optional = true }
+tendermint-proto = "0.33.0"
+tendermint-rpc = {version = "0.33.0", features = ["http-client"] }
 toml = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tonic = "0.9"
 tonic-reflection = "0.9"
 tracing = "0.1.26"
 tracing-subscriber = "0.3.16"
-
-tower-abci = { version = "0.8", optional = true }
+tower-abci = { version = "0.9", optional = true }
 tower = { version = "0.4", features = ["full"], optional = true }
 
 [dev-dependencies]

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 cd "${BASECOIN_SRC}"
 echo ""
 echo "Building basecoin-rs..."
-cargo build --bin basecoin --all-features --target-dir "${BASECOIN_BUILD}"
+cargo build --bin basecoin --target-dir "${BASECOIN_BUILD}"
 
 echo ""
 echo "Setting up chain ibc-0..."

--- a/src/app/abci/mod.rs
+++ b/src/app/abci/mod.rs
@@ -1,0 +1,8 @@
+//! Contains various ABCI implementations to interact with different version of
+//! underlying consensus engine (CometBFT)
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+pub mod v0_37;
+
+#[cfg(all(feature = "v0_38", not(feature = "v0_37")))]
+pub mod v0_38;

--- a/src/app/abci/v0_37/impls.rs
+++ b/src/app/abci/v0_37/impls.rs
@@ -1,0 +1,350 @@
+//! Contains methods specifically implemented for use with the Tower ABCI
+//! interface, compatible with CometBFT version 0.37
+
+use cosmrs::tx::SignerInfo;
+use cosmrs::tx::SignerPublicKey;
+use cosmrs::Tx;
+use ibc::Any;
+use prost::Message;
+use serde_json::Value;
+use tendermint_proto::v0_37::abci::response_process_proposal;
+use tendermint_proto::v0_37::abci::RequestApplySnapshotChunk;
+use tendermint_proto::v0_37::abci::RequestBeginBlock;
+use tendermint_proto::v0_37::abci::RequestCheckTx;
+use tendermint_proto::v0_37::abci::RequestDeliverTx;
+use tendermint_proto::v0_37::abci::RequestEcho;
+use tendermint_proto::v0_37::abci::RequestEndBlock;
+use tendermint_proto::v0_37::abci::RequestInfo;
+use tendermint_proto::v0_37::abci::RequestInitChain;
+use tendermint_proto::v0_37::abci::RequestLoadSnapshotChunk;
+use tendermint_proto::v0_37::abci::RequestOfferSnapshot;
+use tendermint_proto::v0_37::abci::RequestPrepareProposal;
+use tendermint_proto::v0_37::abci::RequestProcessProposal;
+use tendermint_proto::v0_37::abci::RequestQuery;
+use tendermint_proto::v0_37::abci::ResponseApplySnapshotChunk;
+use tendermint_proto::v0_37::abci::ResponseBeginBlock;
+use tendermint_proto::v0_37::abci::ResponseCheckTx;
+use tendermint_proto::v0_37::abci::ResponseCommit;
+use tendermint_proto::v0_37::abci::ResponseDeliverTx;
+use tendermint_proto::v0_37::abci::ResponseEcho;
+use tendermint_proto::v0_37::abci::ResponseEndBlock;
+use tendermint_proto::v0_37::abci::ResponseInfo;
+use tendermint_proto::v0_37::abci::ResponseInitChain;
+use tendermint_proto::v0_37::abci::ResponseListSnapshots;
+use tendermint_proto::v0_37::abci::ResponseLoadSnapshotChunk;
+use tendermint_proto::v0_37::abci::ResponseOfferSnapshot;
+use tendermint_proto::v0_37::abci::ResponsePrepareProposal;
+use tendermint_proto::v0_37::abci::ResponseProcessProposal;
+use tendermint_proto::v0_37::abci::ResponseQuery;
+use tendermint_proto::v0_37::crypto::ProofOp;
+use tendermint_proto::v0_37::crypto::ProofOps;
+use tracing::{debug, info};
+
+use crate::app::BaseCoinApp;
+use crate::error::Error;
+use crate::helper::macros::ResponseFromErrorExt;
+use crate::helper::Height;
+use crate::helper::Path;
+use crate::modules::auth::account::ACCOUNT_PREFIX;
+use crate::modules::types::IdentifiedModule;
+use crate::store::ProvableStore;
+use crate::store::Store;
+
+pub fn echo<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    request: RequestEcho,
+) -> ResponseEcho {
+    ResponseEcho {
+        message: request.message,
+    }
+}
+
+pub fn info<S: Default + ProvableStore + 'static>(
+    app: &BaseCoinApp<S>,
+    request: RequestInfo,
+) -> ResponseInfo {
+    let (last_block_height, last_block_app_hash) = {
+        let state = app.store.read().unwrap();
+        (state.current_height() as i64, state.root_hash())
+    };
+    debug!(
+        "Got info request. Tendermint version: {}; Block version: {}; P2P version: {}, {:?}, {:?}",
+        request.version,
+        request.block_version,
+        request.p2p_version,
+        last_block_height,
+        last_block_app_hash
+    );
+    ResponseInfo {
+        data: "basecoin-rs".to_string(),
+        version: "0.1.0".to_string(),
+        app_version: 1,
+        last_block_height,
+        last_block_app_hash: last_block_app_hash.into(),
+    }
+}
+
+pub fn init_chain<S: Default + ProvableStore + 'static>(
+    app: &BaseCoinApp<S>,
+    request: RequestInitChain,
+) -> ResponseInitChain {
+    debug!("Got init chain request.");
+
+    // safety - we panic on errors to prevent chain creation with invalid genesis config
+    let app_state: Value = serde_json::from_str(
+        &String::from_utf8(request.app_state_bytes.clone().into()).expect("invalid genesis state"),
+    )
+    .expect("genesis state isn't valid JSON");
+    let mut modules = app.modules.write().unwrap();
+    for IdentifiedModule { module, .. } in modules.iter_mut() {
+        module.init(app_state.clone());
+    }
+
+    info!("App initialized");
+
+    ResponseInitChain {
+        consensus_params: request.consensus_params,
+        validators: vec![], // use validator set proposed by tendermint (ie. in the genesis file)
+        app_hash: app.store.write().unwrap().root_hash().into(),
+    }
+}
+
+pub fn query<S: Default + ProvableStore + 'static>(
+    app: &BaseCoinApp<S>,
+    request: RequestQuery,
+) -> ResponseQuery {
+    debug!("Got query request: {:?}", request);
+
+    let path: Option<Path> = request.path.try_into().ok();
+    let modules = app.modules.read().unwrap();
+    let height = Height::from(request.height as u64);
+    for IdentifiedModule { id, module } in modules.iter() {
+        match module.query(&request.data, path.as_ref(), height, request.prove) {
+            // success - implies query was handled by this module, so return response
+            Ok(result) => {
+                let store = app.store.read().unwrap();
+                let proof_ops = if request.prove {
+                    let proof = store.get_proof(height, &id.clone().into()).unwrap();
+                    let mut buffer = Vec::new();
+                    proof.encode(&mut buffer).unwrap(); // safety - cannot fail since buf is a vector
+
+                    let mut ops = vec![];
+                    if let Some(mut proofs) = result.proof {
+                        ops.append(&mut proofs);
+                    }
+                    ops.push(ProofOp {
+                        r#type: "".to_string(),
+                        key: id.to_string().into_bytes(),
+                        data: buffer,
+                    });
+                    Some(ProofOps { ops })
+                } else {
+                    None
+                };
+
+                return ResponseQuery {
+                    code: 0,
+                    log: "exists".to_string(),
+                    key: request.data,
+                    value: result.data.into(),
+                    proof_ops,
+                    height: store.current_height() as i64,
+                    ..Default::default()
+                };
+            }
+            // `Error::NotHandled` - implies query isn't known or was intercepted but not
+            // responded to by this module, so try with next module
+            Err(Error::NotHandled) => continue,
+            // Other error - return immediately
+            Err(e) => return ResponseQuery::from_error(1, format!("query error: {e:?}")),
+        }
+    }
+    ResponseQuery::from_error(1, "query msg not handled")
+}
+
+pub fn check_tx<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestCheckTx,
+) -> ResponseCheckTx {
+    Default::default()
+}
+
+pub fn deliver_tx<S: Default + ProvableStore + 'static>(
+    app: &BaseCoinApp<S>,
+    request: RequestDeliverTx,
+) -> ResponseDeliverTx {
+    debug!("Got deliverTx request: {request:?}");
+
+    let tx: Tx = match request.tx.as_ref().try_into() {
+        Ok(tx) => tx,
+        Err(err) => {
+            return ResponseDeliverTx::from_error(
+                1,
+                format!("failed to decode incoming tx bytes: {err}"),
+            );
+        }
+    };
+
+    // Extract `AccountId` of first signer
+    let signer = {
+        let pubkey = match tx.auth_info.signer_infos.first() {
+            Some(&SignerInfo {
+                public_key: Some(SignerPublicKey::Single(pubkey)),
+                ..
+            }) => pubkey,
+            _ => return ResponseDeliverTx::from_error(2, "Empty signers"),
+        };
+        if let Ok(signer) = pubkey.account_id(ACCOUNT_PREFIX) {
+            signer
+        } else {
+            return ResponseDeliverTx::from_error(2, "Invalid signer");
+        }
+    };
+
+    if tx.body.messages.is_empty() {
+        return ResponseDeliverTx::from_error(2, "Empty Tx");
+    }
+
+    let mut events = vec![];
+    for message in tx.body.messages {
+        let message = Any {
+            type_url: message.type_url,
+            value: message.value,
+        };
+
+        // try to deliver message to every module
+        match app.deliver_msg(message, &signer) {
+            // success - append events and continue with next message
+            Ok(mut msg_events) => {
+                events.append(&mut msg_events);
+            }
+            // return on first error -
+            // either an error that occurred during execution of this message OR no module
+            // could handle this message
+            Err(e) => {
+                // reset changes from other messages in this tx
+                let mut modules = app.modules.write().unwrap();
+                for IdentifiedModule { module, .. } in modules.iter_mut() {
+                    module.store_mut().reset();
+                }
+                app.store.write().unwrap().reset();
+                return ResponseDeliverTx::from_error(2, format!("deliver failed with error: {e}"));
+            }
+        }
+    }
+
+    ResponseDeliverTx {
+        log: "success".to_owned(),
+        events,
+        ..ResponseDeliverTx::default()
+    }
+}
+
+pub fn commit<S: Default + ProvableStore + 'static>(app: &BaseCoinApp<S>) -> ResponseCommit {
+    let mut modules = app.modules.write().unwrap();
+    for IdentifiedModule { id, module } in modules.iter_mut() {
+        module
+            .store_mut()
+            .commit()
+            .expect("failed to commit to state");
+        let mut state = app.store.write().unwrap();
+        state
+            .set(id.clone().into(), module.store().root_hash())
+            .expect("failed to update sub-store commitment");
+    }
+
+    let mut state = app.store.write().unwrap();
+    let data = state.commit().expect("failed to commit to state");
+    info!(
+        "Committed height {} with hash({})",
+        state.current_height() - 1,
+        data.iter().map(|b| format!("{b:02X}")).collect::<String>()
+    );
+    ResponseCommit {
+        data: data.into(),
+        retain_height: 0,
+    }
+}
+
+pub fn begin_block<S: Default + ProvableStore + 'static>(
+    app: &BaseCoinApp<S>,
+    request: RequestBeginBlock,
+) -> ResponseBeginBlock {
+    debug!("Got begin block request.");
+
+    let mut modules = app.modules.write().unwrap();
+    let mut events = vec![];
+    let header = request.header.unwrap().try_into().unwrap();
+    for IdentifiedModule { module, .. } in modules.iter_mut() {
+        events.extend(module.begin_block(&header));
+    }
+
+    ResponseBeginBlock { events }
+}
+
+pub fn end_block<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestEndBlock,
+) -> ResponseEndBlock {
+    Default::default()
+}
+
+pub fn list_snapshots<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+) -> ResponseListSnapshots {
+    Default::default()
+}
+
+pub fn offer_snapshot<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestOfferSnapshot,
+) -> ResponseOfferSnapshot {
+    Default::default()
+}
+
+pub fn load_snapshot_chunk<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestLoadSnapshotChunk,
+) -> ResponseLoadSnapshotChunk {
+    Default::default()
+}
+
+pub fn apply_snapshot_chunk<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestApplySnapshotChunk,
+) -> ResponseApplySnapshotChunk {
+    Default::default()
+}
+
+pub fn prepare_proposal<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    request: RequestPrepareProposal,
+) -> ResponsePrepareProposal {
+    let RequestPrepareProposal {
+        mut txs,
+        max_tx_bytes,
+        ..
+    } = request;
+    let max_tx_bytes: usize = max_tx_bytes.try_into().unwrap_or(0);
+    let mut total_tx_bytes: usize = txs
+        .iter()
+        .map(|tx| tx.len())
+        .fold(0, |acc, len| acc.saturating_add(len));
+    while total_tx_bytes > max_tx_bytes {
+        if let Some(tx) = txs.pop() {
+            total_tx_bytes = total_tx_bytes.saturating_sub(tx.len());
+        } else {
+            break;
+        }
+    }
+    ResponsePrepareProposal { txs }
+}
+
+pub fn process_proposal<S: Default + ProvableStore + 'static>(
+    _app: &BaseCoinApp<S>,
+    _request: RequestProcessProposal,
+) -> ResponseProcessProposal {
+    ResponseProcessProposal {
+        status: response_process_proposal::ProposalStatus::Accept as i32,
+    }
+}

--- a/src/app/abci/v0_37/mod.rs
+++ b/src/app/abci/v0_37/mod.rs
@@ -1,0 +1,2 @@
+pub mod impls;
+pub mod tower_abci;

--- a/src/app/abci/v0_37/tower_abci.rs
+++ b/src/app/abci/v0_37/tower_abci.rs
@@ -1,28 +1,35 @@
+//! This module contains the `tower_abci` implementation for the BaseCoin application.
+
 use std::future::{self, Future};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use tendermint::v0_37::abci::response::Response as AbciResponse;
 use tendermint::v0_37::abci::Request as AbciRequest;
-use tendermint_abci::Application;
 
-use tendermint_proto::abci::RequestApplySnapshotChunk;
-use tendermint_proto::abci::RequestBeginBlock;
-use tendermint_proto::abci::RequestCheckTx;
-use tendermint_proto::abci::RequestDeliverTx;
-use tendermint_proto::abci::RequestEcho;
-use tendermint_proto::abci::RequestEndBlock;
-use tendermint_proto::abci::RequestInfo;
-use tendermint_proto::abci::RequestInitChain;
-use tendermint_proto::abci::RequestLoadSnapshotChunk;
-use tendermint_proto::abci::RequestOfferSnapshot;
-use tendermint_proto::abci::RequestQuery;
+use tendermint_proto::v0_37::abci::RequestApplySnapshotChunk;
+use tendermint_proto::v0_37::abci::RequestBeginBlock;
+use tendermint_proto::v0_37::abci::RequestCheckTx;
+use tendermint_proto::v0_37::abci::RequestDeliverTx;
+use tendermint_proto::v0_37::abci::RequestEcho;
+use tendermint_proto::v0_37::abci::RequestEndBlock;
+use tendermint_proto::v0_37::abci::RequestInfo;
+use tendermint_proto::v0_37::abci::RequestInitChain;
+use tendermint_proto::v0_37::abci::RequestLoadSnapshotChunk;
+use tendermint_proto::v0_37::abci::RequestOfferSnapshot;
+use tendermint_proto::v0_37::abci::RequestQuery;
 
 use tower::Service;
 use tower_abci::BoxError;
 
 use crate::app::BaseCoinApp;
 use crate::store::ProvableStore;
+
+use super::impls::{
+    apply_snapshot_chunk, begin_block, check_tx, commit, deliver_tx, echo, end_block, info,
+    init_chain, list_snapshots, load_snapshot_chunk, offer_snapshot, prepare_proposal,
+    process_proposal, query,
+};
 
 /// We have to create this type since the compiler doesn't think that
 /// `dyn Future<Output = Result<AbciResponse, BoxError>> + Send`
@@ -46,7 +53,7 @@ where
             AbciRequest::Echo(domain_req) => {
                 let proto_req: RequestEcho = domain_req.into();
 
-                let proto_resp = self.echo(proto_req);
+                let proto_resp = echo(self, proto_req);
 
                 AbciResponse::Echo(proto_resp.try_into().unwrap())
             }
@@ -54,90 +61,90 @@ where
             AbciRequest::Info(domain_req) => {
                 let proto_req: RequestInfo = domain_req.into();
 
-                let proto_resp = self.info(proto_req);
+                let proto_resp = info(self, proto_req);
 
                 AbciResponse::Info(proto_resp.try_into().unwrap())
             }
             AbciRequest::InitChain(domain_req) => {
                 let proto_req: RequestInitChain = domain_req.into();
 
-                let proto_resp = self.init_chain(proto_req);
+                let proto_resp = init_chain(self, proto_req);
 
                 AbciResponse::InitChain(proto_resp.try_into().unwrap())
             }
             AbciRequest::Query(domain_req) => {
                 let proto_req: RequestQuery = domain_req.into();
 
-                let proto_resp = self.query(proto_req);
+                let proto_resp = query(self, proto_req);
 
                 AbciResponse::Query(proto_resp.try_into().unwrap())
             }
             AbciRequest::BeginBlock(domain_req) => {
                 let proto_req: RequestBeginBlock = domain_req.into();
 
-                let proto_resp = self.begin_block(proto_req);
+                let proto_resp = begin_block(self, proto_req);
 
                 AbciResponse::BeginBlock(proto_resp.try_into().unwrap())
             }
             AbciRequest::CheckTx(domain_req) => {
                 let proto_req: RequestCheckTx = domain_req.into();
 
-                let proto_resp = self.check_tx(proto_req);
+                let proto_resp = check_tx(self, proto_req);
 
                 AbciResponse::CheckTx(proto_resp.try_into().unwrap())
             }
             AbciRequest::DeliverTx(domain_req) => {
                 let proto_req: RequestDeliverTx = domain_req.into();
 
-                let proto_resp = self.deliver_tx(proto_req);
+                let proto_resp = deliver_tx(self, proto_req);
 
                 AbciResponse::DeliverTx(proto_resp.try_into().unwrap())
             }
             AbciRequest::EndBlock(domain_req) => {
                 let proto_req: RequestEndBlock = domain_req.into();
 
-                let proto_resp = self.end_block(proto_req);
+                let proto_resp = end_block(self, proto_req);
 
                 AbciResponse::EndBlock(proto_resp.try_into().unwrap())
             }
             AbciRequest::Commit => {
-                let proto_resp = self.commit();
+                let proto_resp = commit(self);
 
                 AbciResponse::Commit(proto_resp.try_into().unwrap())
             }
             AbciRequest::ListSnapshots => {
-                let proto_resp = self.list_snapshots();
+                let proto_resp = list_snapshots(self);
 
                 AbciResponse::ListSnapshots(proto_resp.try_into().unwrap())
             }
             AbciRequest::OfferSnapshot(domain_req) => {
                 let proto_req: RequestOfferSnapshot = domain_req.into();
 
-                let proto_resp = self.offer_snapshot(proto_req);
+                let proto_resp = offer_snapshot(self, proto_req);
 
                 AbciResponse::OfferSnapshot(proto_resp.try_into().unwrap())
             }
             AbciRequest::LoadSnapshotChunk(domain_req) => {
                 let proto_req: RequestLoadSnapshotChunk = domain_req.into();
 
-                let proto_resp = self.load_snapshot_chunk(proto_req);
+                let proto_resp = load_snapshot_chunk(self, proto_req);
 
                 AbciResponse::LoadSnapshotChunk(proto_resp.try_into().unwrap())
             }
             AbciRequest::ApplySnapshotChunk(domain_req) => {
                 let proto_req: RequestApplySnapshotChunk = domain_req.into();
 
-                let proto_resp = self.apply_snapshot_chunk(proto_req);
+                let proto_resp = apply_snapshot_chunk(self, proto_req);
 
                 AbciResponse::ApplySnapshotChunk(proto_resp.try_into().unwrap())
             }
             AbciRequest::PrepareProposal(domain_req) => {
-                let proto_resp = self.prepare_proposal(domain_req.into());
+                let proto_resp = prepare_proposal(self, domain_req.into());
 
                 AbciResponse::PrepareProposal(proto_resp.try_into().unwrap())
             }
             AbciRequest::ProcessProposal(domain_req) => {
-                let proto_resp = self.process_proposal(domain_req.into());
+                let proto_resp = process_proposal(self, domain_req.into());
 
                 AbciResponse::ProcessProposal(proto_resp.try_into().unwrap())
             }

--- a/src/app/abci/v0_38/mod.rs
+++ b/src/app/abci/v0_38/mod.rs
@@ -1,0 +1,1 @@
+pub mod tendermint;

--- a/src/app/builder.rs
+++ b/src/app/builder.rs
@@ -3,6 +3,7 @@ use tracing::error;
 
 use cosmrs::AccountId;
 use ibc_proto::google::protobuf::Any;
+use tendermint::abci::Event;
 
 use crate::error::Error;
 use crate::helper::Identifier;
@@ -15,12 +16,6 @@ use crate::store::ProvableStore;
 use crate::store::RevertibleStore;
 use crate::store::SharedRw;
 use crate::store::SharedStore;
-
-#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::abci::Event;
-
-#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::abci::Event;
 
 pub struct Builder<S> {
     store: MainStore<S>,

--- a/src/app/builder.rs
+++ b/src/app/builder.rs
@@ -3,21 +3,24 @@ use tracing::error;
 
 use cosmrs::AccountId;
 use ibc_proto::google::protobuf::Any;
-use tendermint_proto::abci::Event;
 
 use crate::error::Error;
 use crate::helper::Identifier;
 use crate::modules::types::IdentifiedModule;
 use crate::modules::types::ModuleList;
 use crate::modules::types::ModuleStore;
-
 use crate::modules::Module;
-
 use crate::store::MainStore;
 use crate::store::ProvableStore;
 use crate::store::RevertibleStore;
 use crate::store::SharedRw;
 use crate::store::SharedStore;
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::abci::Event;
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::abci::Event;
 
 pub struct Builder<S> {
     store: MainStore<S>,

--- a/src/app/interface/mod.rs
+++ b/src/app/interface/mod.rs
@@ -1,7 +1,0 @@
-//! Different interface implementations to interact with the underlying
-//! consensus engine.
-
-pub mod tendermint;
-
-#[cfg(feature = "tower-abci")]
-pub mod tower_abci;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-pub mod interface;
+pub mod abci;
 pub mod service;
 
 mod builder;

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,11 +1,3 @@
-use ibc_proto::cosmos::base::tendermint::v1beta1::GetNodeInfoResponse;
-use std::convert::TryInto;
-use tracing::debug;
-
-use cosmrs::Tx;
-use tendermint_proto::p2p::DefaultNodeInfo;
-use tonic::{Request, Response, Status};
-
 use ibc_proto::cosmos::base::tendermint::v1beta1::service_server::Service as HealthService;
 use ibc_proto::cosmos::base::tendermint::v1beta1::AbciQueryRequest;
 use ibc_proto::cosmos::base::tendermint::v1beta1::AbciQueryResponse;
@@ -16,13 +8,13 @@ use ibc_proto::cosmos::base::tendermint::v1beta1::GetLatestBlockResponse;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetLatestValidatorSetRequest;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetLatestValidatorSetResponse;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetNodeInfoRequest;
+use ibc_proto::cosmos::base::tendermint::v1beta1::GetNodeInfoResponse;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetSyncingRequest;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetSyncingResponse;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetValidatorSetByHeightRequest;
 use ibc_proto::cosmos::base::tendermint::v1beta1::GetValidatorSetByHeightResponse;
 use ibc_proto::cosmos::base::tendermint::v1beta1::Module as VersionInfoModule;
 use ibc_proto::cosmos::base::tendermint::v1beta1::VersionInfo;
-
 use ibc_proto::cosmos::tx::v1beta1::service_server::Service as TxService;
 use ibc_proto::cosmos::tx::v1beta1::BroadcastTxRequest;
 use ibc_proto::cosmos::tx::v1beta1::BroadcastTxResponse;
@@ -34,6 +26,21 @@ use ibc_proto::cosmos::tx::v1beta1::GetTxsEventRequest;
 use ibc_proto::cosmos::tx::v1beta1::GetTxsEventResponse;
 use ibc_proto::cosmos::tx::v1beta1::SimulateRequest;
 use ibc_proto::cosmos::tx::v1beta1::SimulateResponse;
+use ibc_proto::cosmos::tx::v1beta1::TxDecodeAminoRequest;
+use ibc_proto::cosmos::tx::v1beta1::TxDecodeAminoResponse;
+use ibc_proto::cosmos::tx::v1beta1::TxDecodeRequest;
+use ibc_proto::cosmos::tx::v1beta1::TxDecodeResponse;
+use ibc_proto::cosmos::tx::v1beta1::TxEncodeAminoRequest;
+use ibc_proto::cosmos::tx::v1beta1::TxEncodeAminoResponse;
+use ibc_proto::cosmos::tx::v1beta1::TxEncodeRequest;
+use ibc_proto::cosmos::tx::v1beta1::TxEncodeResponse;
+
+use std::convert::TryInto;
+use tracing::debug;
+
+use cosmrs::Tx;
+use tendermint_proto::p2p::DefaultNodeInfo;
+use tonic::{Request, Response, Status};
 
 use super::builder::BaseCoinApp;
 use crate::store::ProvableStore;
@@ -151,6 +158,34 @@ impl<S: ProvableStore + 'static> TxService for BaseCoinApp<S> {
         &self,
         _request: Request<GetBlockWithTxsRequest>,
     ) -> Result<Response<GetBlockWithTxsResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn tx_decode(
+        &self,
+        _request: Request<TxDecodeRequest>,
+    ) -> Result<Response<TxDecodeResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn tx_encode(
+        &self,
+        _request: Request<TxEncodeRequest>,
+    ) -> Result<Response<TxEncodeResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn tx_encode_amino(
+        &self,
+        _request: Request<TxEncodeAminoRequest>,
+    ) -> Result<Response<TxEncodeAminoResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn tx_decode_amino(
+        &self,
+        _request: Request<TxDecodeAminoRequest>,
+    ) -> Result<Response<TxDecodeAminoResponse>, Status> {
         unimplemented!()
     }
 }

--- a/src/helper/adapts.rs
+++ b/src/helper/adapts.rs
@@ -8,6 +8,11 @@ use std::{
     str::from_utf8,
     str::FromStr,
 };
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::crypto::ProofOp;
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
 use tendermint_proto::crypto::ProofOp;
 
 /// A new type representing a valid ICS024 identifier.

--- a/src/helper/macros.rs
+++ b/src/helper/macros.rs
@@ -6,7 +6,12 @@ use ibc::core::ics24_host::path::{
     CommitmentPath, ConnectionPath, ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
     UpgradeClientPath,
 };
-use tendermint_proto::abci::{ResponseCheckTx, ResponseDeliverTx, ResponseQuery};
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::abci::{ResponseCheckTx, ResponseDeliverTx, ResponseQuery};
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::abci::{ResponseCheckTx, ResponseQuery};
 
 pub(crate) trait ResponseFromErrorExt {
     fn from_error(code: u32, log: impl ToString) -> Self;
@@ -27,7 +32,11 @@ macro_rules! impl_response_error_for {
     };
 }
 
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
 impl_response_error_for!(ResponseQuery, ResponseCheckTx, ResponseDeliverTx);
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+impl_response_error_for!(ResponseQuery, ResponseCheckTx);
 
 macro_rules! impl_into_path_for {
     ($($path:ty),+) => {

--- a/src/modules/auth/impls.rs
+++ b/src/modules/auth/impls.rs
@@ -14,7 +14,6 @@ use ibc_proto::{
     google::protobuf::Any,
 };
 use serde_json::Value;
-use tendermint_proto::abci::Event;
 use tracing::{debug, trace};
 
 use super::account::AccountsPath;
@@ -22,6 +21,12 @@ use super::{
     context::{Account, AccountKeeper, AccountReader},
     service::AuthService,
 };
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::abci::Event;
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::abci::Event;
 
 #[derive(Clone)]
 pub struct Auth<S> {

--- a/src/modules/auth/impls.rs
+++ b/src/modules/auth/impls.rs
@@ -14,6 +14,7 @@ use ibc_proto::{
     google::protobuf::Any,
 };
 use serde_json::Value;
+use tendermint::abci::Event;
 use tracing::{debug, trace};
 
 use super::account::AccountsPath;
@@ -21,12 +22,6 @@ use super::{
     context::{Account, AccountKeeper, AccountReader},
     service::AuthService,
 };
-
-#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::abci::Event;
-
-#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::abci::Event;
 
 #[derive(Clone)]
 pub struct Auth<S> {

--- a/src/modules/auth/service.rs
+++ b/src/modules/auth/service.rs
@@ -6,9 +6,10 @@ use ibc_proto::cosmos::auth::v1beta1::{
     query_server::Query, AddressBytesToStringRequest, AddressBytesToStringResponse,
     AddressStringToBytesRequest, AddressStringToBytesResponse, Bech32PrefixRequest,
     Bech32PrefixResponse, QueryAccountAddressByIdRequest, QueryAccountAddressByIdResponse,
-    QueryAccountRequest, QueryAccountResponse, QueryAccountsRequest, QueryAccountsResponse,
-    QueryModuleAccountByNameRequest, QueryModuleAccountByNameResponse, QueryModuleAccountsRequest,
-    QueryModuleAccountsResponse, QueryParamsRequest, QueryParamsResponse,
+    QueryAccountInfoRequest, QueryAccountInfoResponse, QueryAccountRequest, QueryAccountResponse,
+    QueryAccountsRequest, QueryAccountsResponse, QueryModuleAccountByNameRequest,
+    QueryModuleAccountByNameResponse, QueryModuleAccountsRequest, QueryModuleAccountsResponse,
+    QueryParamsRequest, QueryParamsResponse,
 };
 
 use tonic::{Request, Response, Status};
@@ -41,6 +42,13 @@ impl<S: ProvableStore + 'static> Query for AuthService<S> {
         Ok(Response::new(QueryAccountResponse {
             account: Some(account.into()),
         }))
+    }
+
+    async fn account_info(
+        &self,
+        _request: Request<QueryAccountInfoRequest>,
+    ) -> Result<Response<QueryAccountInfoResponse>, Status> {
+        unimplemented!()
     }
 
     async fn params(

--- a/src/modules/bank/impls.rs
+++ b/src/modules/bank/impls.rs
@@ -7,7 +7,6 @@ use ibc_proto::{cosmos::bank::v1beta1::query_server::QueryServer, google::protob
 use primitive_types::U256;
 use prost::Message;
 use std::{collections::HashMap, convert::TryInto, fmt::Debug, str::FromStr};
-use tendermint_proto::abci::Event;
 use tracing::{debug, trace};
 
 use crate::modules::Module;
@@ -22,6 +21,12 @@ use crate::{
         {JsonStore, TypedStore}, {ProvableStore, Store},
     },
 };
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::abci::Event;
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::abci::Event;
 
 #[derive(Clone)]
 pub struct BankBalanceReader<S> {

--- a/src/modules/bank/impls.rs
+++ b/src/modules/bank/impls.rs
@@ -7,6 +7,7 @@ use ibc_proto::{cosmos::bank::v1beta1::query_server::QueryServer, google::protob
 use primitive_types::U256;
 use prost::Message;
 use std::{collections::HashMap, convert::TryInto, fmt::Debug, str::FromStr};
+use tendermint::abci::Event;
 use tracing::{debug, trace};
 
 use crate::modules::Module;
@@ -21,12 +22,6 @@ use crate::{
         {JsonStore, TypedStore}, {ProvableStore, Store},
     },
 };
-
-#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::abci::Event;
-
-#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::abci::Event;
 
 #[derive(Clone)]
 pub struct BankBalanceReader<S> {

--- a/src/modules/bank/service.rs
+++ b/src/modules/bank/service.rs
@@ -1,12 +1,14 @@
 use ibc_proto::cosmos::{
     bank::v1beta1::{
         query_server::Query, QueryAllBalancesRequest, QueryAllBalancesResponse,
-        QueryBalanceRequest, QueryBalanceResponse, QueryDenomMetadataRequest,
+        QueryBalanceRequest, QueryBalanceResponse, QueryDenomMetadataByQueryStringRequest,
+        QueryDenomMetadataByQueryStringResponse, QueryDenomMetadataRequest,
         QueryDenomMetadataResponse, QueryDenomOwnersRequest, QueryDenomOwnersResponse,
         QueryDenomsMetadataRequest, QueryDenomsMetadataResponse, QueryParamsRequest,
-        QueryParamsResponse, QuerySpendableBalancesRequest, QuerySpendableBalancesResponse,
-        QuerySupplyOfRequest, QuerySupplyOfResponse, QueryTotalSupplyRequest,
-        QueryTotalSupplyResponse,
+        QueryParamsResponse, QuerySendEnabledRequest, QuerySendEnabledResponse,
+        QuerySpendableBalanceByDenomRequest, QuerySpendableBalanceByDenomResponse,
+        QuerySpendableBalancesRequest, QuerySpendableBalancesResponse, QuerySupplyOfRequest,
+        QuerySupplyOfResponse, QueryTotalSupplyRequest, QueryTotalSupplyResponse,
     },
     base::v1beta1::Coin as RawCoin,
 };
@@ -102,6 +104,27 @@ impl<S: ProvableStore + 'static> Query for BankService<S> {
         &self,
         _request: Request<QueryDenomOwnersRequest>,
     ) -> Result<Response<QueryDenomOwnersResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn send_enabled(
+        &self,
+        _request: Request<QuerySendEnabledRequest>,
+    ) -> Result<Response<QuerySendEnabledResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn spendable_balance_by_denom(
+        &self,
+        _request: Request<QuerySpendableBalanceByDenomRequest>,
+    ) -> Result<Response<QuerySpendableBalanceByDenomResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn denom_metadata_by_query_string(
+        &self,
+        _request: Request<QueryDenomMetadataByQueryStringRequest>,
+    ) -> Result<Response<QueryDenomMetadataByQueryStringResponse>, Status> {
         unimplemented!()
     }
 }

--- a/src/modules/gov/impls.rs
+++ b/src/modules/gov/impls.rs
@@ -10,6 +10,7 @@ use ibc::hosts::tendermint::upgrade_proposal::UpgradeProposal;
 use ibc_proto::cosmos::gov::v1beta1::query_server::QueryServer;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::protobuf::Protobuf;
+use tendermint::abci::Event;
 
 use super::path::ProposalPath;
 use super::proposal::Proposal;
@@ -19,12 +20,6 @@ use crate::helper::{Height, Path, QueryResult};
 use crate::modules::gov::msg::MsgSubmitProposal;
 use crate::modules::{Module, Upgrade};
 use crate::store::{ProtobufStore, SharedRw, SharedStore, Store, TypedStore};
-
-#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::abci::Event;
-
-#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::abci::Event;
 
 #[derive(Clone)]
 pub struct Governance<S>
@@ -86,9 +81,7 @@ where
 
             self.proposal_counter += 1;
 
-            Ok(vec![event.try_into().map_err(|e| AppError::Custom {
-                reason: format!("Error converting tendermint event to proto type: {:?}", e),
-            })?])
+            Ok(vec![event])
         } else {
             Err(AppError::NotHandled)
         }

--- a/src/modules/ibc/impls.rs
+++ b/src/modules/ibc/impls.rs
@@ -72,19 +72,13 @@ use derive_more::{From, TryInto};
 
 use ibc::core::dispatch;
 
-use tendermint::{abci::Event as TendermintEvent, block::Header};
+use tendermint::{abci::Event, block::Header};
 
 #[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::{
-    abci::{Event, EventAttribute},
-    crypto::ProofOp,
-};
+use tendermint_proto::v0_37::crypto::ProofOp;
 
 #[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::{
-    abci::{Event, EventAttribute},
-    crypto::ProofOp,
-};
+use tendermint_proto::crypto::ProofOp;
 
 // Note: We define `AnyConsensusState` just to showcase the use of the
 // derive macro. Technically, we could just use `TmConsensusState`
@@ -160,7 +154,7 @@ where
                 .ctx
                 .events
                 .drain(..)
-                .map(|ev| TmEvent(ev.try_into().unwrap()).into())
+                .map(|ev| Event::try_from(ev).unwrap())
                 .collect();
             Ok(events)
         } else if let Ok(transfer_msg) = MsgTransfer::try_from(message) {
@@ -181,7 +175,7 @@ where
                 .events
                 .clone()
                 .into_iter()
-                .map(|ev| TmEvent(ev.try_into().unwrap()).into())
+                .map(|ev| Event::try_from(ev).unwrap())
                 .collect())
         } else {
             Err(AppError::NotHandled)
@@ -335,26 +329,6 @@ where
             store,
             events: Vec::new(),
             logs: Vec::new(),
-        }
-    }
-}
-
-pub(crate) struct TmEvent(pub TendermintEvent);
-
-impl From<TmEvent> for Event {
-    fn from(value: TmEvent) -> Self {
-        Self {
-            r#type: value.0.kind,
-            attributes: value
-                .0
-                .attributes
-                .into_iter()
-                .map(|attr| EventAttribute {
-                    key: attr.key,
-                    value: attr.value,
-                    index: true,
-                })
-                .collect(),
         }
     }
 }

--- a/src/modules/ibc/impls.rs
+++ b/src/modules/ibc/impls.rs
@@ -66,16 +66,25 @@ use std::{
     fmt::Debug,
     time::Duration,
 };
-use tendermint::{abci::Event as TendermintEvent, block::Header};
-use tendermint_proto::{
-    abci::{Event, EventAttribute},
-    crypto::ProofOp,
-};
 use tracing::debug;
 
 use derive_more::{From, TryInto};
 
 use ibc::core::dispatch;
+
+use tendermint::{abci::Event as TendermintEvent, block::Header};
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::{
+    abci::{Event, EventAttribute},
+    crypto::ProofOp,
+};
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::{
+    abci::{Event, EventAttribute},
+    crypto::ProofOp,
+};
 
 // Note: We define `AnyConsensusState` just to showcase the use of the
 // derive macro. Technically, we could just use `TmConsensusState`

--- a/src/modules/ibc/service.rs
+++ b/src/modules/ibc/service.rs
@@ -40,7 +40,8 @@ use ibc_proto::{
             QueryChannelConsensusStateResponse, QueryChannelRequest, QueryChannelResponse,
             QueryChannelsRequest, QueryChannelsResponse, QueryConnectionChannelsRequest,
             QueryConnectionChannelsResponse, QueryNextSequenceReceiveRequest,
-            QueryNextSequenceReceiveResponse, QueryPacketAcknowledgementRequest,
+            QueryNextSequenceReceiveResponse, QueryNextSequenceSendRequest,
+            QueryNextSequenceSendResponse, QueryPacketAcknowledgementRequest,
             QueryPacketAcknowledgementResponse, QueryPacketAcknowledgementsRequest,
             QueryPacketAcknowledgementsResponse, QueryPacketCommitmentRequest,
             QueryPacketCommitmentResponse, QueryPacketCommitmentsRequest,
@@ -665,6 +666,13 @@ impl<S: ProvableStore + 'static> ChannelQuery for IbcChannelService<S> {
                 revision_height: self.packet_commitment_store.current_height(),
             }),
         }))
+    }
+
+    async fn next_sequence_send(
+        &self,
+        _request: Request<QueryNextSequenceSendRequest>,
+    ) -> Result<Response<QueryNextSequenceSendResponse>, Status> {
+        todo!()
     }
 
     /// NextSequenceReceive returns the next receive sequence for a given channel.

--- a/src/modules/module.rs
+++ b/src/modules/module.rs
@@ -3,13 +3,8 @@ use crate::helper::{Height, Identifier as StoreIdentifier, Path, QueryResult};
 use crate::store::impls::SharedStore;
 use cosmrs::AccountId;
 use ibc_proto::google::protobuf::Any;
+use tendermint::abci::Event;
 use tendermint::block::Header;
-
-#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::abci::Event;
-
-#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::abci::Event;
 
 pub trait Module: Send + Sync {
     /// The module's store type.

--- a/src/modules/module.rs
+++ b/src/modules/module.rs
@@ -4,6 +4,11 @@ use crate::store::impls::SharedStore;
 use cosmrs::AccountId;
 use ibc_proto::google::protobuf::Any;
 use tendermint::block::Header;
+
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::abci::Event;
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
 use tendermint_proto::abci::Event;
 
 pub trait Module: Send + Sync {

--- a/src/modules/upgrade/impls.rs
+++ b/src/modules/upgrade/impls.rs
@@ -17,12 +17,13 @@ use ibc::hosts::tendermint::upgrade_proposal::UpgradeExecutionContext;
 use ibc::hosts::tendermint::upgrade_proposal::UpgradeValidationContext;
 use ibc::hosts::tendermint::upgrade_proposal::{Plan, UpgradeChain};
 use ibc::hosts::tendermint::SDK_UPGRADE_QUERY_PATH;
+use tendermint::abci::Event;
 
 #[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
-use tendermint_proto::v0_37::{abci::Event, crypto::ProofOp};
+use tendermint_proto::v0_37::crypto::ProofOp;
 
 #[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
-use tendermint_proto::{abci::Event, crypto::ProofOp};
+use tendermint_proto::crypto::ProofOp;
 
 use super::path::UpgradePlanPath;
 use super::service::UpgradeService;
@@ -169,10 +170,9 @@ where
                 )
                 .unwrap();
 
-                let event: tendermint::abci::Event =
-                    UpgradeChain::new(plan.height, "upgrade".to_string()).into();
+                let event = UpgradeChain::new(plan.height, "upgrade".to_string()).into();
 
-                return vec![event.try_into().unwrap()];
+                return vec![event];
             }
 
             // It should clear the upgrade plan & states once the upgrade is completed.

--- a/src/modules/upgrade/impls.rs
+++ b/src/modules/upgrade/impls.rs
@@ -18,8 +18,11 @@ use ibc::hosts::tendermint::upgrade_proposal::UpgradeValidationContext;
 use ibc::hosts::tendermint::upgrade_proposal::{Plan, UpgradeChain};
 use ibc::hosts::tendermint::SDK_UPGRADE_QUERY_PATH;
 
-use tendermint_proto::abci::Event;
-use tendermint_proto::crypto::ProofOp;
+#[cfg(all(feature = "v0_37", not(feature = "v0_38")))]
+use tendermint_proto::v0_37::{abci::Event, crypto::ProofOp};
+
+#[cfg(any(feature = "v0_38", not(feature = "v0_37")))]
+use tendermint_proto::{abci::Event, crypto::ProofOp};
 
 use super::path::UpgradePlanPath;
 use super::service::UpgradeService;


### PR DESCRIPTION
Tracks: https://github.com/cosmos/ibc-rs/pull/790

### Remark

`tendermint-abci` only supports the latest version of CometBFT and starting from `tendermint-rs` v0.33.0, it is just compatible with CometBFT v0.38. Consequently, to make `basecoin-rs` function with CometBFT v0.37, we only can utilize the `tower_abci` crate at the moment.

By the way, I have also retained the `tendermint_abci` implementation (though it's now faulty) under the `v0_38` feature flag, preserving the possibility of getting the basecoin compatible with CometBFT v0.38 as well in the near future.