### PR TITLE
Implement Growing Store to support deletion 

### DIFF
--- a/crates/app/src/modules/ibc/impls.rs
+++ b/crates/app/src/modules/ibc/impls.rs
@@ -1024,9 +1024,7 @@ where
     }
 
     fn delete_packet_commitment(&mut self, key: &CommitmentPath) -> Result<(), ContextError> {
-        self.packet_commitment_store
-            .set(key.clone(), vec![].into())
-            .map_err(|_| PacketError::ImplementationSpecific)?;
+        self.packet_commitment_store.delete(key.clone());
         Ok(())
     }
 
@@ -1053,9 +1051,7 @@ where
     }
 
     fn delete_packet_acknowledgement(&mut self, ack_path: &AckPath) -> Result<(), ContextError> {
-        self.packet_ack_store
-            .set(ack_path.clone(), vec![].into())
-            .map_err(|_| PacketError::ImplementationSpecific)?;
+        self.packet_ack_store.delete(ack_path.clone());
         Ok(())
     }
 

--- a/crates/app/src/runner.rs
+++ b/crates/app/src/runner.rs
@@ -1,4 +1,4 @@
-use basecoin_store::impls::InMemoryStore;
+use basecoin_store::impls::{GrowingStore, InMemoryStore};
 use ibc_proto::cosmos::base::tendermint::v1beta1::service_server::ServiceServer as HealthServer;
 use ibc_proto::cosmos::tx::v1beta1::service_server::ServiceServer as TxServer;
 
@@ -21,7 +21,7 @@ use tower_abci::v037::split;
 
 pub async fn default_app_runner(server_cfg: ServerConfig) {
     // instantiate the application with a KV store implementation of choice
-    let app_builder = Builder::new(InMemoryStore::default());
+    let app_builder = Builder::new(GrowingStore::<InMemoryStore>::default());
 
     // instantiate modules and setup inter-module communication (if required)
     let auth = Auth::new(app_builder.module_store(&prefix::Auth {}.identifier()));

--- a/crates/store/src/context.rs
+++ b/crates/store/src/context.rs
@@ -16,6 +16,7 @@ pub trait Store: Async + Clone {
     fn get(&self, height: Height, path: &Path) -> Option<Vec<u8>>;
 
     /// Delete specified `path`
+    // TODO(rano): return Result to denote success or failure
     fn delete(&mut self, path: &Path);
 
     /// Commit `Pending` block to canonical chain and create new `Pending`

--- a/crates/store/src/impls/growing.rs
+++ b/crates/store/src/impls/growing.rs
@@ -1,0 +1,112 @@
+use crate::context::ProvableStore;
+use crate::context::Store;
+use crate::types::Height;
+use crate::types::Path;
+
+use ics23::CommitmentProof;
+
+/// GrowingStore does not prune any path.
+/// If the path is set to v, the stored value is v
+/// If the path is deleted, the stored value is []
+/// Note: we should not allow empty vec to store as
+/// this would conflict with the deletion representation.
+#[derive(Clone, Debug)]
+pub struct GrowingStore<S> {
+    store: S,
+}
+
+impl<S> GrowingStore<S> {
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+}
+
+impl<S> Default for GrowingStore<S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        Self::new(S::default())
+    }
+}
+
+impl<S> Store for GrowingStore<S>
+where
+    S: Store,
+{
+    type Error = S::Error;
+
+    #[inline]
+    fn set(&mut self, path: Path, value: Vec<u8>) -> Result<Option<Vec<u8>>, Self::Error> {
+        if value.is_empty() {
+            panic!("empty vec is not allowed to store")
+        }
+        self.store.set(path, value)
+    }
+
+    #[inline]
+    fn get(&self, height: Height, path: &Path) -> Option<Vec<u8>> {
+        self.store.get(height, path).filter(|v| !v.is_empty())
+    }
+
+    #[inline]
+    // TODO(rano): return Result to denote success or failure
+    fn delete(&mut self, path: &Path) {
+        // set value to empty vec to denote the path is deleted.
+        self.store.set(path.clone(), vec![]).expect("delete failed");
+    }
+
+    fn commit(&mut self) -> Result<Vec<u8>, Self::Error> {
+        self.store.commit()
+    }
+
+    #[inline]
+    fn apply(&mut self) -> Result<(), Self::Error> {
+        self.store.apply()
+    }
+
+    #[inline]
+    fn reset(&mut self) {
+        self.store.reset()
+    }
+
+    #[inline]
+    fn prune(&mut self, height: u64) -> Result<u64, Self::Error> {
+        self.store.prune(height)
+    }
+
+    #[inline]
+    fn current_height(&self) -> u64 {
+        self.store.current_height()
+    }
+
+    #[inline]
+    fn get_keys(&self, key_prefix: &Path) -> Vec<Path> {
+        self.store
+            .get_keys(key_prefix)
+            .into_iter()
+            .filter(|k| {
+                self.get(Height::Pending, k)
+                    .filter(|v| !v.is_empty())
+                    .is_some()
+            })
+            .collect()
+    }
+}
+
+impl<S> ProvableStore for GrowingStore<S>
+where
+    S: ProvableStore,
+{
+    #[inline]
+    fn root_hash(&self) -> Vec<u8> {
+        self.store.root_hash()
+    }
+
+    #[inline]
+    fn get_proof(&self, height: Height, key: &Path) -> Option<CommitmentProof> {
+        self.get(height, key)
+            .filter(|v| !v.is_empty())
+            .and_then(|_| self.store.get_proof(height, key))
+    }
+}

--- a/crates/store/src/impls/growing.rs
+++ b/crates/store/src/impls/growing.rs
@@ -112,3 +112,28 @@ where
             .and_then(|_| self.store.get_proof(height, key))
     }
 }
+
+impl<S> GrowingStore<S>
+where
+    S: Store,
+{
+    #[inline]
+    pub fn is_deleted(&self, path: &Path) -> bool {
+        self.get(Height::Pending, path)
+            .filter(|v| v.is_empty())
+            .is_some()
+    }
+
+    #[inline]
+    pub fn deleted_keys(&self, key_prefix: &Path) -> Vec<Path> {
+        self.store
+            .get_keys(key_prefix)
+            .into_iter()
+            .filter(|k| {
+                self.get(Height::Pending, k)
+                    .filter(|v| v.is_empty())
+                    .is_some()
+            })
+            .collect()
+    }
+}

--- a/crates/store/src/impls/growing.rs
+++ b/crates/store/src/impls/growing.rs
@@ -46,6 +46,7 @@ where
 
     #[inline]
     fn get(&self, height: Height, path: &Path) -> Option<Vec<u8>> {
+        // ignore if path is deleted
         self.store.get(height, path).filter(|v| !v.is_empty())
     }
 
@@ -84,6 +85,7 @@ where
         self.store
             .get_keys(key_prefix)
             .into_iter()
+            // ignore the deleted paths
             .filter(|k| {
                 self.get(Height::Pending, k)
                     .filter(|v| !v.is_empty())
@@ -105,6 +107,7 @@ where
     #[inline]
     fn get_proof(&self, height: Height, key: &Path) -> Option<CommitmentProof> {
         self.get(height, key)
+            // ignore if path is deleted
             .filter(|v| !v.is_empty())
             .and_then(|_| self.store.get_proof(height, key))
     }

--- a/crates/store/src/impls/growing.rs
+++ b/crates/store/src/impls/growing.rs
@@ -50,7 +50,6 @@ where
     }
 
     #[inline]
-    // TODO(rano): return Result to denote success or failure
     fn delete(&mut self, path: &Path) {
         // set value to empty vec to denote the path is deleted.
         self.store.set(path.clone(), vec![]).expect("delete failed");

--- a/crates/store/src/impls/mod.rs
+++ b/crates/store/src/impls/mod.rs
@@ -1,7 +1,9 @@
+pub(crate) mod growing;
 pub(crate) mod in_memory;
 pub(crate) mod revertible;
 pub(crate) mod shared;
 
+pub use growing::GrowingStore;
 pub use in_memory::InMemoryStore;
 pub use revertible::RevertibleStore;
 pub use shared::SharedStore;

--- a/crates/store/src/types/store.rs
+++ b/crates/store/src/types/store.rs
@@ -83,7 +83,9 @@ where
 {
     #[inline]
     pub fn set_path(&mut self, path: K) -> Result<(), S::Error> {
-        self.store.set(path.into(), vec![]).map(|_| ())
+        self.store
+            .set(path.into(), NullCodec::encode(&()).unwrap())
+            .map(|_| ())
     }
 
     #[inline]

--- a/crates/store/src/utils/codec.rs
+++ b/crates/store/src/utils/codec.rs
@@ -42,12 +42,16 @@ impl Codec for NullCodec {
     type Encoded = Vec<u8>;
 
     fn encode(_d: &Self::Type) -> Option<Self::Encoded> {
-        Some(vec![])
+        // using [0x00] to represent null
+        Some(vec![0x00])
     }
 
     fn decode(bytes: &[u8]) -> Option<Self::Type> {
-        assert!(bytes.is_empty());
-        Some(())
+        match bytes {
+            // the encoded bytes must be [0x00]
+            [0x00] => Some(()),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Our Merkle Tree, used in [`InMemoryStore`](https://github.com/informalsystems/basecoin-rs/blob/824dd3b5b4dbadb006bf9a789d57ef4462e5dc4e/crates/store/src/impls/in_memory.rs#L11), doesn't implement deletion. So the [`InMemoryStore::delete`](https://github.com/informalsystems/basecoin-rs/blob/824dd3b5b4dbadb006bf9a789d57ef4462e5dc4e/crates/store/src/impls/in_memory.rs#L63) is left unimplemented and panics if it is accessed.

This PR offers a wrapped `InMemoryStore` that supports deletion naively by setting the path with an empty byte vector.

The store is called _Growing_ as no paths are really deleted - as they are only _marked_ as deleted.

Note: It is possible to implement this directly in `InMemoryStore`. But this way, `InMemoryStore` stays truthful to the original Merkle Tree API. Otherwise, each `InMemoryStore` method needs to be changed to handle the deletion case separately. When our Merkle Tree implements _deletion_, we will implement `InMemoryStor::delete` directly using `AvlTree::delete`.