### PR TITLE
imp: make `avl` module public

### DIFF
--- a/crates/store/src/avl/mod.rs
+++ b/crates/store/src/avl/mod.rs
@@ -12,18 +12,18 @@
 //!
 //! For more info, see [AVL Tree on wikipedia](https://en.wikipedia.org/wiki/AVL_tree),
 
-pub use as_bytes::{AsBytes, ByteSlice};
-pub use node::AvlNode;
-pub use proof::get_proof_spec;
-use tendermint::hash::Algorithm;
-pub use tree::AvlTree;
-
 mod as_bytes;
 mod node;
 mod proof;
 mod tree;
 
+pub use as_bytes::{AsBytes, ByteSlice};
+pub use node::AvlNode;
+pub use proof::get_proof_spec;
+pub use tree::AvlTree;
+
 #[cfg(test)]
 mod tests;
 
+use tendermint::hash::Algorithm;
 const HASH_ALGO: Algorithm = Algorithm::Sha256;

--- a/crates/store/src/avl/proof.rs
+++ b/crates/store/src/avl/proof.rs
@@ -6,7 +6,6 @@ use ics23::{HashOp, InnerSpec, LeafOp, LengthOp, ProofSpec};
 
 pub const LEAF_PREFIX: [u8; 64] = [0; 64]; // 64 bytes of zeroes.
 
-#[allow(dead_code)]
 /// Return the `ProofSpec` of tendermock AVL Tree.
 pub fn get_proof_spec() -> ProofSpec {
     ProofSpec {

--- a/crates/store/src/avl/tree.rs
+++ b/crates/store/src/avl/tree.rs
@@ -31,7 +31,6 @@ impl<K: Ord + AsBytes, V: Borrow<[u8]>> AvlTree<K, V> {
         AvlTree { root: None }
     }
 
-    #[allow(dead_code)]
     /// Return the hash of the merkle tree root, if it has at least one node.
     pub fn root_hash(&self) -> Option<&Hash> {
         Some(&self.root.as_ref()?.merkle_hash)
@@ -77,7 +76,6 @@ impl<K: Ord + AsBytes, V: Borrow<[u8]>> AvlTree<K, V> {
         }
     }
 
-    #[allow(dead_code)]
     /// Return an existence proof for the given element, if it exists.
     pub fn get_proof<Q: ?Sized>(&self, key: &Q) -> Option<CommitmentProof>
     where
@@ -197,7 +195,6 @@ impl<K: Ord + AsBytes, V: Borrow<[u8]>> AvlTree<K, V> {
         std::mem::swap(root, &mut Some(right))
     }
 
-    #[allow(dead_code)]
     /// Return a list of the keys present in the tree.
     pub fn get_keys(&self) -> Vec<&K> {
         let mut keys = Vec::new();
@@ -205,7 +202,6 @@ impl<K: Ord + AsBytes, V: Borrow<[u8]>> AvlTree<K, V> {
         keys
     }
 
-    #[allow(dead_code)]
     fn get_keys_rec<'a>(node_ref: &'a NodeRef<K, V>, keys: &mut Vec<&'a K>) {
         if let Some(node) = node_ref {
             Self::get_keys_rec(&node.left, keys);

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,4 +1,4 @@
-pub(crate) mod avl;
+pub mod avl;
 pub mod context;
 pub mod impls;
 pub mod types;


### PR DESCRIPTION
### Description

Since `basecoin` is currently used mainly for testing purposes and parts of the `avl` module such as `get_proof_spec()` can be reused by other projects (In our case `sovereign-ibc`), it is safe to make it public.