### PR TITLE
imp: get access to `bank` and expose types from modules other than `ibc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -358,9 +358,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -411,9 +411,9 @@ checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cosmos-sdk-proto"
@@ -682,12 +682,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "group"
@@ -907,9 +907,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdrhistogram"
@@ -1533,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1569,9 +1569,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1617,9 +1617,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1672,7 +1672,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1769,7 +1769,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2058,16 +2058,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2095,7 +2095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2180,7 +2180,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2417,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2428,9 +2428,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -2528,7 +2528,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2659,7 +2659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2751,7 +2751,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3145,9 +3145,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3155,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -3170,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3182,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3205,15 +3205,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3256,7 +3256,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -3265,13 +3274,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -3281,10 +3305,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3293,10 +3329,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3305,16 +3353,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
@@ -3332,7 +3398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/app/src/abci/v0_37/impls.rs
+++ b/crates/app/src/abci/v0_37/impls.rs
@@ -49,7 +49,7 @@ use tendermint_proto::v0_37::abci::ResponseQuery;
 use tendermint::merkle::proof::ProofOp;
 use tendermint::merkle::proof::ProofOps;
 
-use crate::modules::auth::account::ACCOUNT_PREFIX;
+use crate::modules::auth::ACCOUNT_PREFIX;
 use crate::modules::types::IdentifiedModule;
 use crate::utils::macros::ResponseFromErrorExt;
 

--- a/crates/app/src/modules/auth/impls.rs
+++ b/crates/app/src/modules/auth/impls.rs
@@ -2,7 +2,7 @@ use crate::modules::auth::account::AccountsPath;
 use crate::modules::auth::account::AuthAccount;
 use crate::modules::auth::context::{Account, AccountKeeper, AccountReader};
 use crate::modules::auth::service::AuthService;
-use crate::modules::bank::util::Denom;
+use crate::modules::bank::Denom;
 use crate::{modules::context::Module, types::error::Error as AppError};
 
 use basecoin_store::context::{ProvableStore, Store};

--- a/crates/app/src/modules/auth/mod.rs
+++ b/crates/app/src/modules/auth/mod.rs
@@ -1,6 +1,15 @@
-pub(crate) mod account;
-pub(crate) mod context;
-pub(crate) mod impls;
-pub(crate) mod service;
+mod account;
+mod context;
+mod impls;
+mod service;
 
-pub use impls::{Auth, AuthAccountKeeper, AuthAccountReader};
+pub use account::*;
+pub use context::*;
+pub use impls::*;
+pub use service::*;
+
+/// Re-exports `auth` module proto types for convenience.
+pub mod proto {
+    pub use cosmrs::AccountId;
+    pub use ibc_proto::cosmos::auth::*;
+}

--- a/crates/app/src/modules/bank/mod.rs
+++ b/crates/app/src/modules/bank/mod.rs
@@ -1,7 +1,17 @@
-pub(crate) mod context;
-pub(crate) mod error;
-pub(crate) mod impls;
-pub(crate) mod service;
-pub(crate) mod util;
+mod context;
+mod error;
+mod impls;
+mod service;
+mod util;
 
-pub use impls::Bank;
+pub use context::*;
+pub use error::*;
+pub use impls::*;
+pub use service::*;
+pub use util::*;
+
+/// Re-exports `bank` module proto types for convenience.
+pub mod proto {
+    pub use cosmrs::Coin;
+    pub use ibc_proto::cosmos::bank::*;
+}

--- a/crates/app/src/modules/gov/impls.rs
+++ b/crates/app/src/modules/gov/impls.rs
@@ -1,15 +1,15 @@
 use super::path::ProposalPath;
 use super::proposal::Proposal;
 use super::service::GovernanceService;
-use crate::modules::context::Module;
+use crate::modules::context::{Identifiable, Module};
 use crate::modules::gov::msg::MsgSubmitProposal;
 use crate::modules::upgrade::Upgrade;
 use crate::types::error::Error as AppError;
 use crate::types::QueryResult;
 
-use basecoin_store::context::Store;
+use basecoin_store::context::{ProvableStore, Store};
 use basecoin_store::impls::SharedStore;
-use basecoin_store::types::{Height, Path, ProtobufStore, TypedStore};
+use basecoin_store::types::{Height, Identifier, Path, ProtobufStore, TypedStore};
 use basecoin_store::utils::{SharedRw, SharedRwExt};
 
 use ibc::cosmos_host::upgrade_proposal::upgrade_client_proposal_handler;
@@ -55,6 +55,14 @@ where
 
     pub fn service(&self) -> QueryServer<GovernanceService<S>> {
         QueryServer::new(GovernanceService(PhantomData))
+    }
+}
+
+impl<S: ProvableStore + Debug> Identifiable for Upgrade<S> {
+    type Identifier = Identifier;
+
+    fn identifier(&self) -> Self::Identifier {
+        "upgrade".to_owned().try_into().unwrap()
     }
 }
 

--- a/crates/app/src/modules/gov/impls.rs
+++ b/crates/app/src/modules/gov/impls.rs
@@ -1,15 +1,15 @@
 use super::path::ProposalPath;
 use super::proposal::Proposal;
 use super::service::GovernanceService;
-use crate::modules::context::{Identifiable, Module};
+use crate::modules::context::Module;
 use crate::modules::gov::msg::MsgSubmitProposal;
 use crate::modules::upgrade::Upgrade;
 use crate::types::error::Error as AppError;
 use crate::types::QueryResult;
 
-use basecoin_store::context::{ProvableStore, Store};
+use basecoin_store::context::Store;
 use basecoin_store::impls::SharedStore;
-use basecoin_store::types::{Height, Identifier, Path, ProtobufStore, TypedStore};
+use basecoin_store::types::{Height, Path, ProtobufStore, TypedStore};
 use basecoin_store::utils::{SharedRw, SharedRwExt};
 
 use ibc::cosmos_host::upgrade_proposal::upgrade_client_proposal_handler;
@@ -55,14 +55,6 @@ where
 
     pub fn service(&self) -> QueryServer<GovernanceService<S>> {
         QueryServer::new(GovernanceService(PhantomData))
-    }
-}
-
-impl<S: ProvableStore + Debug> Identifiable for Upgrade<S> {
-    type Identifier = Identifier;
-
-    fn identifier(&self) -> Self::Identifier {
-        "upgrade".to_owned().try_into().unwrap()
     }
 }
 

--- a/crates/app/src/modules/gov/mod.rs
+++ b/crates/app/src/modules/gov/mod.rs
@@ -1,8 +1,18 @@
-pub(crate) mod error;
-pub(crate) mod impls;
-pub(crate) mod msg;
-pub(crate) mod path;
-pub(crate) mod proposal;
-pub(crate) mod service;
+mod error;
+mod impls;
+mod msg;
+mod path;
+mod proposal;
+mod service;
 
-pub use impls::Governance;
+pub use error::*;
+pub use impls::*;
+pub use msg::*;
+pub use path::*;
+pub use proposal::*;
+pub use service::*;
+
+/// Re-exports `gov` module proto types for convenience.
+pub mod proto {
+    pub use ibc_proto::cosmos::gov::*;
+}

--- a/crates/app/src/modules/gov/msg.rs
+++ b/crates/app/src/modules/gov/msg.rs
@@ -5,7 +5,7 @@ use ibc_proto::cosmos::gov::v1beta1::ProposalStatus;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::Protobuf;
 
-use crate::modules::bank::util::Coin;
+use crate::modules::bank::Coin;
 use crate::types::error::Error;
 
 use super::proposal::Proposal;

--- a/crates/app/src/modules/gov/proposal.rs
+++ b/crates/app/src/modules/gov/proposal.rs
@@ -7,7 +7,7 @@ use ibc_proto::google::protobuf::{Any, Timestamp};
 use ibc_proto::Protobuf;
 
 use super::error::Error;
-use crate::modules::bank::util::Coin;
+use crate::modules::bank::Coin;
 
 pub(crate) const TYPE_URL: &str = "/cosmos.gov.v1beta1.Proposal";
 

--- a/crates/app/src/modules/ibc/impls.rs
+++ b/crates/app/src/modules/ibc/impls.rs
@@ -1,13 +1,14 @@
 use crate::CHAIN_REVISION_NUMBER;
 use crate::{
     modules::{
-        bank::impls::BankBalanceKeeper,
+        bank::BankBalanceKeeper,
         context::{Identifiable, Module},
         ibc::{router::IbcRouter, transfer::IbcTransferModule},
         upgrade::Upgrade,
     },
     types::{error::Error as AppError, QueryResult},
 };
+use basecoin_store::types::Identifier;
 use basecoin_store::{
     context::{ProvableStore, Store},
     impls::SharedStore,
@@ -194,6 +195,14 @@ where
             }
         }
         None
+    }
+}
+
+impl<S: ProvableStore + Debug> Identifiable for Ibc<S> {
+    type Identifier = Identifier;
+
+    fn identifier(&self) -> Self::Identifier {
+        "ibc".to_owned().try_into().unwrap()
     }
 }
 

--- a/crates/app/src/modules/ibc/impls.rs
+++ b/crates/app/src/modules/ibc/impls.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     types::{error::Error as AppError, QueryResult},
 };
-use basecoin_store::types::Identifier;
 use basecoin_store::{
     context::{ProvableStore, Store},
     impls::SharedStore,
@@ -195,14 +194,6 @@ where
             }
         }
         None
-    }
-}
-
-impl<S: ProvableStore + Debug> Identifiable for Ibc<S> {
-    type Identifier = Identifier;
-
-    fn identifier(&self) -> Self::Identifier {
-        "ibc".to_owned().try_into().unwrap()
     }
 }
 

--- a/crates/app/src/modules/ibc/mod.rs
+++ b/crates/app/src/modules/ibc/mod.rs
@@ -1,10 +1,11 @@
-pub mod client_contexts;
-pub mod error;
-pub mod impls;
+mod client_contexts;
+mod error;
+mod impls;
 mod router;
-pub mod transfer;
+mod transfer;
 
-pub use impls::AnyConsensusState;
-pub use impls::Ibc;
-pub use impls::IbcContext;
-pub use transfer::IbcTransferModule;
+pub use client_contexts::*;
+pub use error::*;
+pub use impls::*;
+pub use router::*;
+pub use transfer::*;

--- a/crates/app/src/modules/ibc/router.rs
+++ b/crates/app/src/modules/ibc/router.rs
@@ -1,4 +1,4 @@
-use crate::modules::bank::impls::BankBalanceKeeper;
+use crate::modules::bank::BankBalanceKeeper;
 use crate::modules::ibc::transfer::IbcTransferModule;
 
 use basecoin_store::context::Store;

--- a/crates/app/src/modules/ibc/transfer.rs
+++ b/crates/app/src/modules/ibc/transfer.rs
@@ -1,6 +1,6 @@
-use crate::modules::auth::account::ACCOUNT_PREFIX;
-use crate::modules::bank::context::BankKeeper;
-use crate::modules::bank::util::{Coin, Denom};
+use crate::modules::auth::ACCOUNT_PREFIX;
+use crate::modules::bank::BankKeeper;
+use crate::modules::bank::{Coin, Denom};
 
 use ibc::apps::transfer::context::TokenTransferExecutionContext;
 use ibc::apps::transfer::context::TokenTransferValidationContext;

--- a/crates/app/src/modules/staking/mod.rs
+++ b/crates/app/src/modules/staking/mod.rs
@@ -1,4 +1,10 @@
-pub(crate) mod impls;
-pub(crate) mod service;
+mod impls;
+mod service;
 
-pub use impls::Staking;
+pub use impls::*;
+pub use service::*;
+
+/// Re-exports `staking` module proto types for convenience.
+pub mod proto {
+    pub use ibc_proto::cosmos::staking::*;
+}

--- a/crates/app/src/modules/upgrade/impls.rs
+++ b/crates/app/src/modules/upgrade/impls.rs
@@ -71,14 +71,6 @@ where
     }
 }
 
-// impl<S: ProvableStore + Debug> Identifiable for Upgrade<S> {
-//     type Identifier = Identifier;
-
-//     fn identifier(&self) -> Self::Identifier {
-//         "upgrade".to_owned().try_into().unwrap()
-//     }
-// }
-
 impl<S> Module for Upgrade<S>
 where
     S: ProvableStore + Debug,

--- a/crates/app/src/modules/upgrade/impls.rs
+++ b/crates/app/src/modules/upgrade/impls.rs
@@ -30,7 +30,7 @@ use super::path::UpgradePlanPath;
 use super::query::UPGRADE_PLAN_QUERY_PATH;
 use super::service::UpgradeService;
 use crate::modules::context::Module;
-use crate::modules::ibc::impls::{AnyConsensusState, IbcContext};
+use crate::modules::ibc::{AnyConsensusState, IbcContext};
 use crate::types::error::Error as AppError;
 use crate::types::query::QueryResult;
 
@@ -70,6 +70,14 @@ where
         QueryServer::new(UpgradeService::new(self.store.clone()))
     }
 }
+
+// impl<S: ProvableStore + Debug> Identifiable for Upgrade<S> {
+//     type Identifier = Identifier;
+
+//     fn identifier(&self) -> Self::Identifier {
+//         "upgrade".to_owned().try_into().unwrap()
+//     }
+// }
 
 impl<S> Module for Upgrade<S>
 where

--- a/crates/app/src/modules/upgrade/mod.rs
+++ b/crates/app/src/modules/upgrade/mod.rs
@@ -1,7 +1,14 @@
-pub(crate) mod impls;
-pub(crate) mod path;
-pub(crate) mod query;
-pub(crate) mod service;
+mod impls;
+mod path;
+mod query;
+mod service;
 
-pub use impls::Upgrade;
+pub use impls::*;
+pub use path::*;
 pub use query::*;
+pub use service::*;
+
+/// Re-exports `upgrade` module proto types for convenience.
+pub mod proto {
+    pub use ibc_proto::cosmos::upgrade::*;
+}

--- a/crates/app/src/types/error.rs
+++ b/crates/app/src/types/error.rs
@@ -1,6 +1,6 @@
-use crate::modules::bank::error::Error as BankError;
-use crate::modules::gov::error::Error as GovError;
-use crate::modules::ibc::error::Error as IbcError;
+use crate::modules::bank::Error as BankError;
+use crate::modules::gov::Error as GovError;
+use crate::modules::ibc::Error as IbcError;
 use displaydoc::Display;
 
 #[derive(Debug, Display)]


### PR DESCRIPTION
## Description
This PR provides access to the `bank` module by adding a `bank` method to the `BaseCoinApp` definition. It also lets us access types from different basecoin's modules, not just `ibc`. This is useful for testing in `sovereign-ibc` project, where we need to check things like account balances to make sure everything is working as it should.