### PR TITLE
Revertible in-memory store

### DIFF
--- a/basecoin/app/src/builder.rs
+++ b/basecoin/app/src/builder.rs
@@ -5,7 +5,7 @@ use basecoin_modules::context::Module;
 use basecoin_modules::error::Error;
 use basecoin_modules::types::{IdentifiedModule, ModuleList, ModuleStore};
 use basecoin_store::context::ProvableStore;
-use basecoin_store::impls::{RevertibleStore, SharedStore};
+use basecoin_store::impls::SharedStore;
 use basecoin_store::types::{Identifier, MainStore};
 use basecoin_store::utils::{SharedRw, SharedRwExt};
 use cosmrs::AccountId;
@@ -22,7 +22,7 @@ impl<S: Default + ProvableStore> Builder<S> {
     /// Constructor.
     pub fn new(store: S) -> Self {
         Self {
-            store: SharedStore::new(RevertibleStore::new(store)),
+            store: SharedStore::new(store),
             modules: Arc::new(RwLock::new(vec![])),
         }
     }
@@ -35,7 +35,7 @@ impl<S: Default + ProvableStore> Builder<S> {
             .iter()
             .find(|m| &m.id == prefix)
             .map(|IdentifiedModule { module, .. }| module.store().share())
-            .unwrap_or_else(|| SharedStore::new(ModuleStore::new(S::default())))
+            .unwrap_or_else(|| SharedStore::new(S::default()))
     }
 
     #[inline]

--- a/basecoin/modules/src/types.rs
+++ b/basecoin/modules/src/types.rs
@@ -1,11 +1,10 @@
-use basecoin_store::impls::RevertibleStore;
 use basecoin_store::types::Identifier;
 use tendermint::merkle::proof::ProofOp;
 
 use crate::context::Module;
 
 pub type ModuleList<S> = Vec<IdentifiedModule<S>>;
-pub type ModuleStore<S> = RevertibleStore<S>;
+pub type ModuleStore<S> = S;
 
 pub struct IdentifiedModule<S> {
     pub id: Identifier,

--- a/basecoin/src/helper.rs
+++ b/basecoin/src/helper.rs
@@ -6,11 +6,10 @@ use basecoin_modules::bank::Bank;
 use basecoin_modules::context::{prefix, Identifiable};
 use basecoin_modules::ibc::Ibc;
 use basecoin_store::context::ProvableStore;
-use basecoin_store::impls::RevertibleStore;
 use basecoin_store::utils::SharedRwExt;
 
 /// Gives access to the IBC module.
-pub fn ibc<S>(app: BaseCoinApp<S>) -> Ibc<RevertibleStore<S>>
+pub fn ibc<S>(app: BaseCoinApp<S>) -> Ibc<S>
 where
     S: ProvableStore + Default + Debug,
 {
@@ -19,23 +18,12 @@ where
     modules
         .iter()
         .find(|m| m.id == prefix::Ibc {}.identifier())
-        .and_then(|m| {
-            m.module
-                .as_any()
-                .downcast_ref::<Ibc<RevertibleStore<S>>>()
-                .cloned()
-        })
+        .and_then(|m| m.module.as_any().downcast_ref::<Ibc<S>>().cloned())
         .expect("IBC module not found")
 }
 
 /// Gives access to the Bank module.
-pub fn bank<S>(
-    app: BaseCoinApp<S>,
-) -> Bank<
-    RevertibleStore<S>,
-    AuthAccountReader<RevertibleStore<S>>,
-    AuthAccountKeeper<RevertibleStore<S>>,
->
+pub fn bank<S>(app: BaseCoinApp<S>) -> Bank<S, AuthAccountReader<S>, AuthAccountKeeper<S>>
 where
     S: ProvableStore + Default + Debug,
 {
@@ -47,11 +35,7 @@ where
         .and_then(|m| {
             m.module
                 .as_any()
-                .downcast_ref::<Bank<
-                    RevertibleStore<S>,
-                    AuthAccountReader<RevertibleStore<S>>,
-                    AuthAccountKeeper<RevertibleStore<S>>,
-                >>()
+                .downcast_ref::<Bank<S, AuthAccountReader<S>, AuthAccountKeeper<S>>>()
                 .cloned()
         })
         .expect("Bank module not found")

--- a/basecoin/store/src/impls/in_memory.rs
+++ b/basecoin/store/src/impls/in_memory.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 use ics23::CommitmentProof;
 use tendermint::hash::Algorithm;
 use tendermint::Hash;
@@ -91,7 +93,7 @@ impl Default for InMemoryStore {
 }
 
 impl Store for InMemoryStore {
-    type Error = (); // underlying store ops are infallible
+    type Error = Infallible;
 
     fn set(&mut self, path: Path, value: Vec<u8>) -> Result<Option<Vec<u8>>, Self::Error> {
         trace!("set at path = {}", path.to_string());

--- a/basecoin/store/src/impls/in_memory.rs
+++ b/basecoin/store/src/impls/in_memory.rs
@@ -197,9 +197,11 @@ mod tests {
         pv.push(3);
         pv.push(4);
         pv.push(5);
-        assert_eq!(pv.len(), 5);
+        assert_eq!(pv.original_length(), 5);
         pv.prune(2);
-        assert_eq!(pv.len(), 5);
+        assert_eq!(pv.original_length(), 5);
+        assert_eq!(pv.pruned_length(), 2);
+        assert_eq!(pv.current_length(), 3);
         assert_eq!(pv.get(0), None);
         assert_eq!(pv.get(1), None);
         assert_eq!(pv.get(2), Some(&3));

--- a/basecoin/store/src/impls/in_memory.rs
+++ b/basecoin/store/src/impls/in_memory.rs
@@ -35,11 +35,16 @@ impl<T> PrunedVec<T> {
         self.vec.last()
     }
 
-    pub fn len(&self) -> usize {
-        self.vec
-            .len()
-            .checked_add(self.pruned)
-            .expect("no overflow")
+    pub fn current_length(&self) -> usize {
+        self.vec.len()
+    }
+
+    pub fn pruned_length(&self) -> usize {
+        self.pruned
+    }
+
+    pub fn original_length(&self) -> usize {
+        self.current_length() + self.pruned_length()
     }
 
     pub fn prune(&mut self, index: usize) {
@@ -145,7 +150,7 @@ impl Store for InMemoryStore {
     }
 
     fn current_height(&self) -> u64 {
-        self.store.len() as u64
+        self.store.original_length() as u64
     }
 
     fn get_keys(&self, key_prefix: &Path) -> Vec<Path> {

--- a/basecoin/store/src/impls/in_memory.rs
+++ b/basecoin/store/src/impls/in_memory.rs
@@ -9,9 +9,16 @@ use crate::avl::{AsBytes, AvlTree};
 use crate::context::{ProvableStore, Store};
 use crate::types::{Height, Path, RawHeight, State};
 
+/// A wrapper type around `Vec` that more easily facilitates the pruning of
+/// its elements at a particular height / index. Keeps track of the latest
+/// height at which its elements were pruned.
+///
+/// This type is used by [`InMemoryStore`] in order to prune old store entries.
 #[derive(Debug, Clone, Default)]
 pub struct PrunedVec<T> {
     vec: Vec<T>,
+    /// The latest index at which elements were pruned. In other words,
+    /// elements that exist at and before this index are no longer accessible.
     pruned: usize,
 }
 

--- a/basecoin/store/src/impls/in_memory.rs
+++ b/basecoin/store/src/impls/in_memory.rs
@@ -9,7 +9,7 @@ use crate::avl::{AsBytes, AvlTree};
 use crate::context::{ProvableStore, Store};
 use crate::types::{Height, Path, RawHeight, State};
 
-/// A wrapper type around `Vec` that more easily facilitates the pruning of
+/// A wrapper type around [`Vec`] that more easily facilitates the pruning of
 /// its elements at a particular height / index. Keeps track of the latest
 /// height at which its elements were pruned.
 ///
@@ -57,6 +57,17 @@ impl<T> PrunedVec<T> {
 }
 
 /// An in-memory store backed by an AvlTree.
+///
+/// [`InMemoryStore`] has two copies of the current working store - `staged` and `pending`.
+///
+/// Each transaction works on `pending` copy. When a transaction returns,
+/// - If it succeeds, the store _applies_ the transaction changes by copying `pending` to `staged`.
+/// - If it fails, the store _reverts_ the transaction changes by copying `staged` to `pending`.
+///
+/// When a block is committed, the staged copy is copied into the committed store.
+///
+/// Note that, it is not production-friendly. After each transaction, a whole store is copied
+/// from `pending` to `staged` or `staged` to `pending`.
 #[derive(Clone, Debug)]
 pub struct InMemoryStore {
     /// collection of states corresponding to every committed block height

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -5,6 +5,17 @@ use crate::context::{ProvableStore, Store};
 use crate::types::{Height, Path};
 
 /// A wrapper store that implements rudimentary `apply()`/`reset()` support for other stores
+///
+/// [`RevertibleStore`] relies on maintaining a list of processed operations - `delete` and `set`.
+/// If it has to revert on a failed transaction, it _reverts_ the previous operations.
+/// - If it was overwriting `set`, `set` with the old value.
+/// - If it was `delete`, `set` the old value.
+/// - If it was non-overwriting `set`, `delete` the current value.
+///
+/// Note that, this introduces a problem to maintain a deterministic Merkle root hash.
+/// An overwriting `set` doesn't reorganize a Merkle tree - but non-overwriting `set` and `delete` may
+/// reorganize a Merkle tree - which may change the root hash. But a Merkle store should
+/// have no effect on a failed transaction.
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {
     /// backing store

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -4,18 +4,18 @@ use tracing::trace;
 use crate::context::{ProvableStore, Store};
 use crate::types::{Height, Path};
 
-/// A wrapper store that implements rudimentary `apply()`/`reset()` support for other stores
+/// A wrapper store that implements rudimentary `apply()`/`reset()` support for other stores.
 ///
 /// [`RevertibleStore`] relies on maintaining a list of processed operations - `delete` and `set`.
-/// If it has to revert on a failed transaction, it _reverts_ the previous operations.
-/// - If it was overwriting `set`, `set` with the old value.
-/// - If it was `delete`, `set` the old value.
-/// - If it was non-overwriting `set`, `delete` the current value.
 ///
-/// Note that, this introduces a problem to maintain a deterministic Merkle root hash.
-/// An overwriting `set` doesn't reorganize a Merkle tree - but non-overwriting `set` and `delete` may
-/// reorganize a Merkle tree - which may change the root hash. But a Merkle store should
-/// have no effect on a failed transaction.
+/// If it has to revert a failed transaction, it _reverts_ the previous operations as so:
+/// - If reverting an overwriting `set` or `delete` operation, it performs a `set` with the old value.
+/// - If reverting a non-overwriting `set`, it `delete`s the current value.
+///
+/// Note that this scheme makes it trickier to maintain deterministic Merkle root hashes:
+/// an overwriting `set` doesn't reorganize a Merkle tree - but non-overwriting `set` and `delete`
+/// operations may reorganize a Merkle tree - which may change the root hash. However, a Merkle
+/// store should have no effect on a failed transaction.
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {
     /// backing store

--- a/basecoin/store/src/types/height.rs
+++ b/basecoin/store/src/types/height.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Display, Formatter};
-
 /// Block height
 pub type RawHeight = u64;
 
@@ -9,16 +7,6 @@ pub enum Height {
     Pending,
     Latest,
     Stable(RawHeight), // or equivalently `tendermint::block::Height`
-}
-
-impl Display for Height {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Height::Pending => write!(f, "pending"),
-            Height::Latest => write!(f, "latest"),
-            Height::Stable(height) => write!(f, "{}", height),
-        }
-    }
 }
 
 impl From<RawHeight> for Height {

--- a/basecoin/store/src/types/store.rs
+++ b/basecoin/store/src/types/store.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use crate::avl::AvlTree;
 use crate::context::Store;
-use crate::impls::{RevertibleStore, SharedStore};
+use crate::impls::SharedStore;
 use crate::types::{Height, Path, RawHeight};
 use crate::utils::codec::{BinCodec, JsonCodec, NullCodec, ProtobufCodec};
 use crate::utils::Codec;
@@ -12,7 +12,7 @@ use crate::utils::Codec;
 // The value is a `Vec<u8>` to allow stored types to choose their own serde.
 pub type State = AvlTree<Path, Vec<u8>>;
 
-pub type MainStore<S> = SharedStore<RevertibleStore<S>>;
+pub type MainStore<S> = SharedStore<S>;
 
 /// A `TypedStore` that uses the `JsonCodec`
 pub type JsonStore<S, K, V> = TypedStore<S, K, JsonCodec<V>>;


### PR DESCRIPTION
Closes #159

Supports revertibility in in-memory store directly, without RevertibleStore wrapper.

---

## Revert in `RevertibleStore`

The old `RevertibleStore` relies on maintaining a list of processed operations - `write` and `delete`. If it has to revert on a failed transaction, it _tries_ to revert the previous operations.

- if it was `overwrite`, `overwrite` with the old value
- if it was `delete`, `insert` the old value
- if it was `insert`, `delete` the current value

### Problem

But this creates a problem with a deterministic Merkle root hash. `overwrite`-ing doesn't change the Merkle tree - but `insert` and `delete` may reorganize the Merkle tree. And we don't want to reorganize a Merkle tree on a failed transaction. That is, storage should have zero effect on a failed transaction.

Also, we don't have deletion support until #141 is merged. This is why we have this non-termination bug present #129.

##  Revert in new `InMemoryStore`

The new `InMemoryStore` has two copies of the current working store. These two copies are `staged` and `pending`.

Each transaction works on `pending` copy. When a transaction returns,
- If it succeeds, the store _applies_ the transaction changes by copying `pending` to `staged`.
- If it fails, the store _reverts_ the transaction changes by copying `staged` to `pending`.

When a block is committed, the staged copy is copied into the record of all committed stores.

### Problem

This is not production-friendly. After each transaction, a whole store is copied from `pending` to `staged` or `staged` to `pending`. 