### PR TITLE
chore: track ibc-rs `v0.51.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arrayref"
@@ -102,25 +102,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -214,7 +214,7 @@ dependencies = [
  "tendermint-abci",
  "tendermint-rpc",
  "tokio",
- "toml 0.8.10",
+ "toml 0.8.12",
  "tonic",
  "tonic-reflection",
  "tower-abci",
@@ -304,9 +304,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake2"
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -371,9 +371,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -392,9 +392,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -415,14 +415,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -891,7 +891,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1033,8 +1033,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1046,8 +1046,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1056,8 +1056,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1070,16 +1070,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-app-transfer",
 ]
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1095,8 +1095,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1112,8 +1112,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1126,8 +1126,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1135,8 +1135,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1151,8 +1151,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1166,8 +1166,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1185,8 +1185,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1198,8 +1198,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1214,8 +1214,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1230,8 +1230,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1244,8 +1244,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1256,8 +1256,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1273,8 +1273,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1288,8 +1288,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1308,8 +1308,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1326,8 +1326,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1349,8 +1349,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1360,8 +1360,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1374,8 +1374,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1389,18 +1389,18 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.6.1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "ibc-primitives"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1431,8 +1431,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-query"
-version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=bef3683#bef3683a79b69fe648a86e21fd35a717d94c37ec"
+version = "0.51.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -1795,7 +1795,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1872,7 +1872,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64",
  "bytes",
@@ -2015,11 +2015,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2193,14 +2193,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2215,7 +2215,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2558,22 +2558,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2668,7 +2668,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2683,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2752,11 +2752,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2875,7 +2875,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2983,9 +2983,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "valuable"
@@ -3045,7 +3045,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -3079,7 +3079,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3299,5 +3299,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.55",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,8 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af2325614ae3274b2e70834bea56c1fa2758d802d364d89992b0fe820847fca"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1047,7 +1048,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63113a979118ad1474833bc4f01ad4fe87b17dcdd2f1376a67a2ac59d8c11434"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1057,7 +1059,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff799a080f5c84316eb0b99f25fbc8b1790ab8c71c0ac465f88e4958e5a949"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1071,7 +1074,8 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5325b71c21ea45f8a7f8df412e72a01b50f230b08b4120d6a233aeb4bf7b4a54"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1079,7 +1083,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa7a3fc87f5bf15c521ef2d63120173b074874df99198302b32d36fc5874614"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1096,7 +1101,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24507c8a710df38924981bd087fc52808f12eb5e6fb1e15b49180979a162fe5"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1113,7 +1119,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5beac8a4f0affd642b47d21ac1dfc0d3c5fdccd032789ee40d882d46c1b677e3"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1127,7 +1134,8 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf6dce5f55eac4930a6e00808cd91d9eccffcb8b5d7c4717b57e9a11217be90"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1136,7 +1144,8 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb68e9669c9946dec7453684b5ab05f9c307d908ebe174178bb63a839187f61"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1152,7 +1161,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee95045592a67c58d3efd045c17a0923ce956f43c344d9673ff5de4d359b5f6c"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1167,7 +1177,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804776a40c68a3624b200a51ff9f9506e74d4eaf4dce482b07e68e7b12e6be7b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1186,7 +1197,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015b28dbb91d6ec2bb82eb57bb34f65cf56e1111e61b82181ae6fb794aceac06"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1199,7 +1211,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9413a8d97d2c4c5dd0d1b673a09e43c80aabb209355e60681865f608bac0756"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1215,7 +1228,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a053bd037d7a0d6d42c92321e4eafbc3a7dba2730a9172cb082ddca0215781a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1231,7 +1245,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4202b39be2ef46a110fbe6c258df8721bc5377878a74b9025deafec2d3495e2"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1245,7 +1260,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712bd6ca50a57b98dc514182f8046bb0456311c32950d149d0cc72a1aa07d012"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1257,7 +1273,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86c2819e77deb658886b31cb50629ddca97a688a19cb962336a847305922c43"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1274,7 +1291,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf6cfdfacf8664f178a20269bb4f47252ab1c9a57b2530b2602e8b0b4e29c66"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1289,7 +1307,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032c96b6f1ad4ee17c301335f5d36f0207e837fc351b416fffab9010c63de061"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1309,7 +1328,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce0b51ac76f9542530ac531366702f16c732b1ba911890a153f1769e99a7277b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1327,7 +1347,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6cb1c979d58e146910bca01978c9151cedd2b9eabad7125ae8e14a59695450"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1350,7 +1371,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11fac91a80985a15eb3e0847fc962c21379982b6e06968595a4d274b10202eb"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1361,7 +1383,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4dc0d4b15127ebf3a31841830b57cbae7f3de1823d2e3f81b402fea4f9054e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1375,7 +1398,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60996d3dbd3d40a2b01046b4f3edb8e332f8a72c6ab98ad046262ab9a35bbdb"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1390,7 +1414,8 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.1"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5010acf3b7fec09c24d05b946424a9f7884f9647ed837c1a1676d3eabac154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1425,8 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02bc4f3159464458522624bc2177f4fda02070d56042e652f886a6b738223bd"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1432,7 +1458,8 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=c847f0e#c847f0edeffe0284f5beaf5ca124022864f51071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9f34977f9906193439aebe9ba423d0a4db8cba09e4908aefa095c844b773a5"
 dependencies = [
  "displaydoc",
  "ibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tracing            = "0.1.26"
 tracing-subscriber = "0.3.16"
 
 # ibc dependencies
-ibc              = { git = "https://github.com/cosmos/ibc-rs", rev = "bef3683", default-features = false, features = ["serde"] }
-ibc-query        = { git = "https://github.com/cosmos/ibc-rs", rev = "bef3683", default-features = false }
+ibc              = { git = "https://github.com/cosmos/ibc-rs", rev = "c847f0e", default-features = false, features = ["serde"] }
+ibc-query        = { git = "https://github.com/cosmos/ibc-rs", rev = "c847f0e", default-features = false }
 ibc-proto        = { version = "0.42.2", default-features = false }
 ics23            = { version = "0.11", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tracing            = "0.1.26"
 tracing-subscriber = "0.3.16"
 
 # ibc dependencies
-ibc              = { git = "https://github.com/cosmos/ibc-rs", rev = "c847f0e", default-features = false, features = ["serde"] }
-ibc-query        = { git = "https://github.com/cosmos/ibc-rs", rev = "c847f0e", default-features = false }
+ibc              = { version = "0.51.0", default-features = false, features = ["serde"] }
+ibc-query        = { version = "0.51.0", default-features = false }
 ibc-proto        = { version = "0.42.2", default-features = false }
 ics23            = { version = "0.11", default-features = false }
 


### PR DESCRIPTION
tracks cosmos/ibc-rs#1141

- [ ] ~update rev when the release is merged onto main~
- [x] use `v0.51.0` dependency