### PR TITLE
Move git dependencies to `[patch.crates-io]` section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=300e4c16#300e4c16210af5c347739a8d2de449cc837600a7"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=2214dbe#2214dbee441ff005083841f4cd5983229d08d306"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2591,8 +2591,9 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=300e4c16#300e4c16210af5c347739a8d2de449cc837600a7"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=2214dbe#2214dbee441ff005083841f4cd5983229d08d306"
 dependencies = [
+ "base64",
  "bytes",
  "derive_more",
  "hex",
@@ -2612,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=300e4c16#300e4c16210af5c347739a8d2de449cc837600a7"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=2214dbe#2214dbee441ff005083841f4cd5983229d08d306"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,5 @@ sov-celestia-client     = { version = "0.1.0" }
 [patch.crates-io]
 ibc                     = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67" }
 ibc-query               = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67" }
-sov-celestia-client     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "300e4c16" }
+sov-celestia-client     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "2214dbe" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tracing            = "0.1.26"
 tracing-subscriber = "0.3.16"
 
 # ibc dependencies
-ibc              = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67", default-features = false, features = ["serde"] }
-ibc-query        = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67", default-features = false, features = ["serde"] }
+ibc              = { version = "0.51.0", default-features = false, features = ["serde"] }
+ibc-query        = { version = "0.51.0", default-features = false, features = ["serde"] }
 ibc-proto        = { version = "0.42.2", default-features = false }
 ics23            = { version = "0.11", default-features = false }
 
@@ -45,3 +45,10 @@ tendermint       = { version = "0.34", default-features = false }
 tendermint-abci  = { version = "0.34", default-features = false }
 tendermint-proto = { version = "0.34", default-features = false }
 tendermint-rpc   = { version = "0.34", default-features = false }
+
+sov-celestia-client     = { version = "0.1.0" }
+
+[patch.crates-io]
+ibc                     = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67" }
+ibc-query               = { git = "https://github.com/cosmos/ibc-rs.git", rev = "c579628c67" }
+sov-celestia-client     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "300e4c16" }

--- a/basecoin/modules/Cargo.toml
+++ b/basecoin/modules/Cargo.toml
@@ -26,11 +26,11 @@ tonic              = { workspace = true }
 tracing            = { workspace = true }
 
 # ibc dependencies
-ibc                = { workspace = true }
-ibc-proto          = { workspace = true, features = ["server", "proto-descriptor", "serde"] }
-ibc-query          = { workspace = true }
-ics23              = { workspace = true, features = ["host-functions"] }
-sov-celestia-client = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "300e4c16" }
+ibc                     = { workspace = true }
+ibc-proto               = { workspace = true, features = ["server", "proto-descriptor", "serde"] }
+ibc-query               = { workspace = true }
+ics23                   = { workspace = true, features = ["host-functions"] }
+sov-celestia-client     = { workspace = true }
 
 # tendermint dependencies
 tendermint         = { workspace = true }


### PR DESCRIPTION
This allows the crates that depend on `basecoin`, such as sovereign-ibc, to be able to more easily override the git dependency version by specifying their `[patch.crates-io]` section