### PR TITLE
imp: investigate why upgrade-client halts `gaiad`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
           cp -r cometbft-config/ ~/.cometbft/config
           mkdir -p ~/.hermes
           cp hermes-config.toml ~/.hermes/config.toml
-          cp one-chain ~
+          cp one-chain.sh ~
           cp user_seed.json ~
           cp Makefile ..
           cp -r tests/ ~

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,15 +5,11 @@ on:
     branches:
       - main
 
-jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master' }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   ibc-integration:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,11 +17,11 @@ jobs:
   ibc-integration:
     runs-on: ubuntu-latest
     env:
-      COMETBFT_VERSION: 0.37.1
-      GAIA_VERSION: 7.1.1
-      HERMES_VERSION: 1.8.0
-      GRPCURL_VERSION: 1.8.7
-      RUST_VERSION: 1.65
+      COMETBFT_VERSION: 0.37.4
+      GAIA_VERSION: 15.2.0
+      HERMES_VERSION: 1.8.2
+      GRPCURL_VERSION: 1.9.1
+      RUST_VERSION: 1.77.2
       IBC_COMMITISH: master
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -108,4 +108,17 @@ jobs:
         working-directory: ~
         run: |
           mkdir -p "${LOG_DIR}"
-          entrypoint.sh make test -j4
+          if ! entrypoint.sh make test -j4; then
+            echo ""
+            echo "Tests failed. Printing logs..."
+            echo ""
+            echo "Gaia logs:"
+            tail -100 "${HOME}/data/ibc-0.log"
+            echo ""
+            echo "Basecoin logs:"
+            tail -100 "${LOG_DIR}/basecoin.log"
+            echo ""
+            echo "CometBFT logs:"
+            tail -100 "${LOG_DIR}/cometbft.log"
+            exit 1
+          fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -95,10 +95,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          override: true
 
       - name: Set environment variables
         run: |

--- a/basecoin/app/src/service.rs
+++ b/basecoin/app/src/service.rs
@@ -66,7 +66,7 @@ impl<S: ProvableStore> HealthService for BaseCoinApp<S> {
         &self,
         _request: Request<GetSyncingRequest>,
     ) -> Result<Response<GetSyncingResponse>, Status> {
-        unimplemented!()
+        Ok(Response::new(GetSyncingResponse { syncing: false }))
     }
 
     async fn get_latest_block(

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,7 +19,7 @@ ENV IBC_COMMITISH=master
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 COPY cometbft-config/ /basecoin/.cometbft/config
 COPY hermes-config.toml /basecoin/.hermes/config.toml
-COPY one-chain /basecoin/one-chain
+COPY one-chain.sh /basecoin/one-chain.sh
 COPY user_seed.json /basecoin/user_seed.json
 COPY tests/ /basecoin/tests
 

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -8,7 +8,7 @@ create-channel:
 	bash ~/tests/create-channel.sh
 	@echo "Channel created"
 
-token-transfer: create-channel
+token-transfer: upgrade-client
 	@echo "Transferring tokens..."
 	bash ~/tests/token-transfer.sh
 	@echo "Tokens transferred"

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -8,12 +8,14 @@ create-channel:
 	bash ~/tests/create-channel.sh
 	@echo "Channel created"
 
-token-transfer: upgrade-client
+token-transfer: create-channel
 	@echo "Transferring tokens..."
 	bash ~/tests/token-transfer.sh
 	@echo "Tokens transferred"
 
-upgrade-client: create-channel
+# This test halts `gaiad` at the end.
+# So, this must be the last test that involves `gaiad`.
+upgrade-client: token-transfer
 	@echo "Upgrading client..."
 	bash ~/tests/upgrade-client.sh
 	@echo "Client upgraded"

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -23,7 +23,7 @@ cargo build --bin basecoin --target-dir "${BASECOIN_BUILD}"
 echo ""
 echo "Setting up chain ibc-0..."
 mkdir -p "${CHAIN_DATA}"
-"${HOME}/one-chain" gaiad ibc-0 "${CHAIN_DATA}" 26657 26656 6060 9090 100000000000
+"${HOME}/one-chain.sh" gaiad ibc-0 "${CHAIN_DATA}" 26657 26656 6060 9090 100000000000
 
 echo ""
 echo "Configuring Hermes..."

--- a/ci/hermes-config.toml
+++ b/ci/hermes-config.toml
@@ -14,7 +14,7 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 4000000
 gas_price = { price = 0.001, denom = 'stake' }
-gas_multiplier = 1.1
+gas_multiplier = 1.5
 max_msg_num = 30
 max_tx_size = 2097152
 clock_drift = '5s'
@@ -37,7 +37,7 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 4000000
 gas_price = { price = 0.001, denom = 'basecoin' }
-gas_multiplier = 1.1
+gas_multiplier = 1.5
 max_msg_num = 30
 max_tx_size = 2097152
 clock_drift = '5s'

--- a/ci/one-chain
+++ b/ci/one-chain
@@ -77,7 +77,7 @@ USER_COINS="${STAKE},${SAMOLEANS}samoleans"
 # Hermes also needs stake to perform actions
 HERMES_COINS="${STAKE},${SAMOLEANS}samoleans"
 
-$BINARY --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID init $CHAIN_ID &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID init $CHAIN_ID
 sleep 1
 echo "Creating validator key"
 $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add validator --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/validator_seed.json 2>&1
@@ -91,25 +91,25 @@ sleep 1
 
 # Add samoleans to user
 USER=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER $USER_COINS &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER $USER_COINS
 sleep 1
 
 # Add samoleans to user2
 USER2=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user2 -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER2 $USER_COINS &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER2 $USER_COINS
 sleep 1
 
 
 # Add stake to validator
 VALIDATOR=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show validator -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $VALIDATOR $STAKE &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $VALIDATOR $STAKE
 sleep 1
 
 # Stake everything
-$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis gentx validator --keyring-backend="test" --chain-id $CHAIN_ID $STAKE &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis gentx validator --keyring-backend="test" --chain-id $CHAIN_ID $STAKE
 sleep 1
 
-$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis collect-gentxs &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis collect-gentxs
 sleep 1
 
 # Check platform

--- a/ci/one-chain
+++ b/ci/one-chain
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 # Copied from https://github.com/cosmos/relayer/tree/master/scripts
 
 usage() {

--- a/ci/one-chain
+++ b/ci/one-chain
@@ -148,7 +148,7 @@ fi
 
 # Start gaia
 echo "Start gaia on grpc port: $GRPC_PORT..."
-$BINARY --home $CHAIN_DIR/$CHAIN_ID start --pruning=nothing --grpc.address="0.0.0.0:$GRPC_PORT" --log_level error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
+$BINARY --home $CHAIN_DIR/$CHAIN_ID start --minimum-gas-prices=0stake --pruning=nothing --grpc.address="0.0.0.0:$GRPC_PORT" --log_level=error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
 
 # Show validator's and user's balance
 sleep 3

--- a/ci/one-chain
+++ b/ci/one-chain
@@ -91,25 +91,25 @@ sleep 1
 
 # Add samoleans to user
 USER=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $USER $USER_COINS &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER $USER_COINS &> /dev/null
 sleep 1
 
 # Add samoleans to user2
 USER2=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user2 -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $USER2 $USER_COINS &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $USER2 $USER_COINS &> /dev/null
 sleep 1
 
 
 # Add stake to validator
 VALIDATOR=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show validator -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $VALIDATOR $STAKE &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis add-genesis-account $VALIDATOR $STAKE &> /dev/null
 sleep 1
 
 # Stake everything
-$BINARY --home $CHAIN_DIR/$CHAIN_ID gentx validator --keyring-backend="test" --chain-id $CHAIN_ID $STAKE &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis gentx validator --keyring-backend="test" --chain-id $CHAIN_ID $STAKE &> /dev/null
 sleep 1
 
-$BINARY --home $CHAIN_DIR/$CHAIN_ID collect-gentxs &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID genesis collect-gentxs &> /dev/null
 sleep 1
 
 # Check platform

--- a/ci/one-chain.sh
+++ b/ci/one-chain.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Copied from https://github.com/cosmos/relayer/tree/master/scripts
-
 usage() {
   echo "Usage: $0 BINARY CHAIN_ID CHAIN_DIR RPC_PORT P2P_PORT PROFILING_PORT GRPC_PORT SAMOLEANS"
   echo "Example: $0 gaiad ibc-0 ./data 26657 26656 6060 9090 100"

--- a/ci/tests/upgrade-client.sh
+++ b/ci/tests/upgrade-client.sh
@@ -5,11 +5,11 @@ BASECOIN_BIN=${BASECOIN_BIN:-${HOME}/build/basecoin-rs/debug/basecoin}
 
 echo "Test client upgradability of basecoin-0 on ibc-0"
 
-hermes tx upgrade-chain --reference-chain basecoin-0 --host-chain ibc-0 --host-client 07-tendermint-0 --amount 10000000 --height-offset 20
+hermes tx upgrade-chain --reference-chain basecoin-0 --host-chain ibc-0 --host-client 07-tendermint-1 --amount 10000000 --height-offset 20
 sleep 3s
 plan_height=$("${BASECOIN_BIN}" query upgrade plan | grep -o 'height: [0-9]*' | awk '{print $2}')
 echo "Waiting for upgrade plan to execute at height $plan_height..."
-hermes upgrade client --host-chain ibc-0 --client 07-tendermint-0 --upgrade-height $plan_height
+hermes upgrade client --host-chain ibc-0 --client 07-tendermint-1 --upgrade-height $plan_height
 
 echo "Test client upgradability of ibc-0 on basecoin-0"
 


### PR DESCRIPTION
Closes #177 

- updates CI dependencies (gaia, hermes, cometbft, grpcurl, rust toolchain).
- in case of failure, prints last 200 lines from the logs from gaia, basecoin, cometbft.
- uses github workflow concurrency option.
- uses actions-rust-lang/setup-rust-toolchain to setup rust.
- implements `HealthService::get_syncing`.
- rename `one-chain` script to `one-chain.sh`.