### PR TITLE
deprecate `GrowingStore` and `RevertibleStore`

### DIFF
--- a/basecoin/store/src/impls/growing.rs
+++ b/basecoin/store/src/impls/growing.rs
@@ -8,7 +8,10 @@ use crate::types::{Height, Path};
 /// If the path is deleted, the stored value is []
 /// Note: we should not allow empty vec to store as
 /// this would conflict with the deletion representation.
-#[deprecated(since = "TBD", note = "GrowingStore does not implement deletion and has been deprecated in favor of InMemoryStore, which supports deletion of AVL tree nodes.")]
+#[deprecated(
+    since = "TBD",
+    note = "GrowingStore does not implement deletion and has been deprecated in favor of InMemoryStore, which implements deletion of AVL tree nodes."
+)]
 #[derive(Clone, Debug)]
 pub struct GrowingStore<S> {
     store: S,

--- a/basecoin/store/src/impls/growing.rs
+++ b/basecoin/store/src/impls/growing.rs
@@ -8,7 +8,7 @@ use crate::types::{Height, Path};
 /// If the path is deleted, the stored value is []
 /// Note: we should not allow empty vec to store as
 /// this would conflict with the deletion representation.
-#[deprecated(since = "TBD", note = "InMemoryStore implements deletion in AVL tree.")]
+#[deprecated(since = "TBD", note = "GrowingStore does not implement deletion and has been deprecated in favor of InMemoryStore, which supports deletion of AVL tree nodes.")]
 #[derive(Clone, Debug)]
 pub struct GrowingStore<S> {
     store: S,

--- a/basecoin/store/src/impls/growing.rs
+++ b/basecoin/store/src/impls/growing.rs
@@ -10,7 +10,7 @@ use crate::types::{Height, Path};
 /// this would conflict with the deletion representation.
 #[deprecated(
     since = "TBD",
-    note = "GrowingStore does not implement deletion and has been deprecated in favor of InMemoryStore, which implements deletion of AVL tree nodes."
+    note = "GrowingStore does not implement deletion. Use InMemoryStore which implements deletion of AVL tree nodes."
 )]
 #[derive(Clone, Debug)]
 pub struct GrowingStore<S> {

--- a/basecoin/store/src/impls/growing.rs
+++ b/basecoin/store/src/impls/growing.rs
@@ -8,6 +8,7 @@ use crate::types::{Height, Path};
 /// If the path is deleted, the stored value is []
 /// Note: we should not allow empty vec to store as
 /// this would conflict with the deletion representation.
+#[deprecated(since = "TBD", note = "InMemoryStore implements deletion in AVL tree.")]
 #[derive(Clone, Debug)]
 pub struct GrowingStore<S> {
     store: S,

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -18,7 +18,7 @@ use crate::types::{Height, Path};
 /// store should have no effect on a failed transaction.
 #[deprecated(
     since = "TBD",
-    note = "RevertibleStore has a bug where using the operation log to revert changes does not guarantee deterministic Merkle root hashes."
+    note = "RevertibleStore has a bug where using the operation log to revert changes does not guarantee deterministic Merkle root hashes. Use InMemoryStore which implements a correct rollback procedure."
 )]
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -18,7 +18,7 @@ use crate::types::{Height, Path};
 /// store should have no effect on a failed transaction.
 #[deprecated(
     since = "TBD",
-    note = "Using operation log to revert changes does not guarantee deterministic Merkle root hash."
+    note = "RevertibleStore has been deprecated due to a bug where using the operation log to revert changes does not guarantee deterministic Merkle root hashes."
 )]
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {
@@ -101,7 +101,7 @@ where
 
     /// Revert all operations in the operation log.
     ///
-    /// This method doesn't guarantee the Merkle tree with the exactly previous root hash.
+    /// This method doesn't guarantee that the Merkle tree will be reverted to the correct previous root hash.
     /// It should be avoided. Use `InMemoryStore` directly which implements rollback directly.
     ///
     /// GH issue: informalsystems/basecoin-rs#129

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -18,7 +18,7 @@ use crate::types::{Height, Path};
 /// store should have no effect on a failed transaction.
 #[deprecated(
     since = "TBD",
-    note = "RevertibleStore has been deprecated due to a bug where using the operation log to revert changes does not guarantee deterministic Merkle root hashes."
+    note = "RevertibleStore has a bug where using the operation log to revert changes does not guarantee deterministic Merkle root hashes."
 )]
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {
@@ -102,7 +102,7 @@ where
     /// Revert all operations in the operation log.
     ///
     /// This method doesn't guarantee that the Merkle tree will be reverted to the correct previous root hash.
-    /// It should be avoided. Use `InMemoryStore` directly which implements rollback directly.
+    /// It should be avoided. Use `InMemoryStore` directly which implements a correct rollback procedure.
     ///
     /// GH issue: informalsystems/basecoin-rs#129
     #[inline]

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -16,6 +16,10 @@ use crate::types::{Height, Path};
 /// an overwriting `set` doesn't reorganize a Merkle tree - but non-overwriting `set` and `delete`
 /// operations may reorganize a Merkle tree - which may change the root hash. However, a Merkle
 /// store should have no effect on a failed transaction.
+#[deprecated(
+    since = "TBD",
+    note = "Using operation log to revert changes does not guarantee deterministic Merkle root hash."
+)]
 #[derive(Clone, Debug)]
 pub struct RevertibleStore<S> {
     /// backing store

--- a/basecoin/store/src/impls/revertible.rs
+++ b/basecoin/store/src/impls/revertible.rs
@@ -99,6 +99,12 @@ where
         Ok(())
     }
 
+    /// Revert all operations in the operation log.
+    ///
+    /// This method doesn't guarantee the Merkle tree with the exactly previous root hash.
+    /// It should be avoided. Use `InMemoryStore` directly which implements rollback directly.
+    ///
+    /// GH issue: informalsystems/basecoin-rs#129
     #[inline]
     fn reset(&mut self) {
         // note that we do NOT call the backing store's reset here - this allows users to create


### PR DESCRIPTION
Close #181

These two stores are incorrect.

- GrowingStore doesn't implement deletion. Instead, it stores an empty byte array at the deleted key. This is not correct for generating non-membership proof.
- RevertibleStore has a non-termination bug (#129)

Now that the `InMemoryStore` directly supports deletion, rollbacks, and non-membership proofs - we can deprecate these stores.