### PR TITLE
Bump `ibc-proto` to v0.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1128,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1408,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
+checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=01506d4#01506d4c9275760c5437f8e6af23771b77927e12"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
 dependencies = [
  "displaydoc",
  "ibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1128,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1408,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=34d28ce#34d28ce41c2840da4523e43c3db2b382b08e95d4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=1b3aed9#1b3aed9d8dbbe645e6aa4e49547dc48cf9f2cbb3"
 dependencies = [
  "displaydoc",
  "ibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tracing-subscriber = "0.3.16"
 # ibc dependencies
 ibc       = { version = "0.53.0", default-features = false, features = [ "serde" ] }
 ibc-query = { version = "0.53.0", default-features = false }
-ibc-proto = { version = "0.44.0", default-features = false }
+ibc-proto = { version = "0.45.0", default-features = false }
 ics23     = { version = "0.11", default-features = false }
 
 # tendermint dependencies
@@ -45,5 +45,5 @@ tendermint-rpc   = { version = "0.36", default-features = false }
 tower-abci = { version = "0.14" }
 
 [patch.crates-io]
-ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "01506d4" }
-ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "01506d4" }
+ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "34d28ce" }
+ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "34d28ce" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ tendermint-rpc   = { version = "0.36", default-features = false }
 tower-abci = { version = "0.14" }
 
 [patch.crates-io]
-ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "34d28ce" }
-ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "34d28ce" }
+ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "1b3aed9" }
+ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "1b3aed9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ tendermint-rpc   = { version = "0.36", default-features = false }
 tower-abci = { version = "0.14" }
 
 [patch.crates-io]
-ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "1b3aed9" }
-ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "1b3aed9" }
+ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "5779e86" }
+ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "5779e86" }


### PR DESCRIPTION
This PR also updates the `ibc` and `ibc-query` revs to the version of ibc-rs that uses `borsh` v1.