### PR TITLE
Reflect `ibc-rs` PR 1318 changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,8 +1242,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e95f55d8c5cf080fc3824031e5d8026c96cc0707ffb19cf9db0deda0cd5ea186"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1256,8 +1255,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b227c94f3c5602a7771a8909e8e5403b3f5cdc0144ef229d46ec9f54118cc5a"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1267,8 +1265,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631d60b8c1dbd74ba2609d5a7787ff73925fb4c444fe29ef62dbc7fa9b1bde94"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1282,8 +1279,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00955ee844a6fee8e13068432c8d9d9b52fd2471121d73fb0ea9f6865e24a587"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1291,8 +1287,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3699afb0fd43f67b08318e48031c6e7efd40cd9dd2507e17cbc00e188ccef60f"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1309,8 +1304,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2bbdc8edd4aa65a02e4255763e2ec11fefcbe019c784373bbba72e2a5cdf1f"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1327,8 +1321,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488bee9150aa0600781007ed7d2c5cd957f037c428ba72c40a04e522d66f27b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1342,8 +1335,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ee36072817816bc71e4e33bdf587ed3a05d0ca7625236653112ef15a7e5ff2"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1352,8 +1344,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cddf3c01d56ca1ee49b9ffd8c5e8e6f8c650711fb93c88dcabae4b726f07a43"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1369,8 +1360,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93dd27559decbcc30ea4a7d37870a2d819e0c701ce789d4a99419a289eacc6d"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1385,8 +1375,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0c1d8da6c2f6843d951ec2ccfe0df93f32e96f136870bed90182981648cfb1"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1405,8 +1394,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fdd2d1cbb6b4e003dec33ed8303254341e75bd828d028aa71deddf67f9ec45"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1419,8 +1407,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969c1f3411b2ca4e6a041ab8e222937f2cea5a26b26beca45164d05468dc4de4"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1436,8 +1423,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6799c8383872fd4bf523dceaadd8c884c2748ad1a542e84e93dcbbd667efc59"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1453,8 +1439,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6e681fc7336d546f7606670b107e8487fd99867f317c2add7eb79b41060d09"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1469,8 +1454,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26abf3cc801896860728d1780c9895994f6ff5ab7bb2af3e5686963c0901654e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1482,8 +1466,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c07695b8fba97aded7003031480dd25bdb194fdc1f0cca02508f2dcefe10385"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1500,8 +1483,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658069f1a43790c6dc1288a980a30e1a1667bf0af53fb3f836d56b7ab7ec728c"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1516,8 +1498,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3931e41a6feae1819c59788d2a0a4a08fa51bac3024b63cec4fb88d13882dbee"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1537,8 +1518,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856e37bcabd67cf26934bd127189844b9fc40004fb545b80bef899bef9092df3"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1556,8 +1536,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b203c12236140e627270c4d7d469ab2e776a94c22da9051b020303bc6b21f"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1580,8 +1559,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1b9b6000e8f55cc09e00f7552a7c4acb8c42548ef76088e2154ca839387aba"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1592,8 +1570,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195c93f19d8c9c6e36e518656ca381cd4f86131515ad4e99f7e6d2a1836b7b7e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1607,8 +1584,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d27386ce69af9d3e3c63e590cf6e1d466f948c2b3e2b0911872cb6d88adf5b"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1623,8 +1599,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0eb1d08a424a2d714652aca4c2738a016c90f4eb78f6f64913f9fe2c77fe34"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1634,8 +1609,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95544f3bc56c8c9cc335910d5aa567a6743a3aeeb33084bb3e31dc6801936edb"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1667,8 +1641,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93a963dcbb97c796c236e6a20367e3db6c3f43c472ead4cde037460a175a48e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=a36348b#a36348b949194552f5a6e9d979f91129538e8023"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3593,13 +3566,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "ibc"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
-
-[[patch.unused]]
-name = "ibc-query"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,8 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95f55d8c5cf080fc3824031e5d8026c96cc0707ffb19cf9db0deda0cd5ea186"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1254,8 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b227c94f3c5602a7771a8909e8e5403b3f5cdc0144ef229d46ec9f54118cc5a"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1264,8 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631d60b8c1dbd74ba2609d5a7787ff73925fb4c444fe29ef62dbc7fa9b1bde94"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1278,16 +1281,18 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00955ee844a6fee8e13068432c8d9d9b52fd2471121d73fb0ea9f6865e24a587"
 dependencies = [
  "ibc-app-transfer",
 ]
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3699afb0fd43f67b08318e48031c6e7efd40cd9dd2507e17cbc00e188ccef60f"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1303,8 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2bbdc8edd4aa65a02e4255763e2ec11fefcbe019c784373bbba72e2a5cdf1f"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1320,8 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488bee9150aa0600781007ed7d2c5cd957f037c428ba72c40a04e522d66f27b3"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1334,8 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ee36072817816bc71e4e33bdf587ed3a05d0ca7625236653112ef15a7e5ff2"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1343,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cddf3c01d56ca1ee49b9ffd8c5e8e6f8c650711fb93c88dcabae4b726f07a43"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1359,8 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93dd27559decbcc30ea4a7d37870a2d819e0c701ce789d4a99419a289eacc6d"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1374,8 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0c1d8da6c2f6843d951ec2ccfe0df93f32e96f136870bed90182981648cfb1"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1393,8 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3fdd2d1cbb6b4e003dec33ed8303254341e75bd828d028aa71deddf67f9ec45"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1406,8 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969c1f3411b2ca4e6a041ab8e222937f2cea5a26b26beca45164d05468dc4de4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1422,8 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6799c8383872fd4bf523dceaadd8c884c2748ad1a542e84e93dcbbd667efc59"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1438,8 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6e681fc7336d546f7606670b107e8487fd99867f317c2add7eb79b41060d09"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1453,8 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26abf3cc801896860728d1780c9895994f6ff5ab7bb2af3e5686963c0901654e"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1465,8 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c07695b8fba97aded7003031480dd25bdb194fdc1f0cca02508f2dcefe10385"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1482,8 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658069f1a43790c6dc1288a980a30e1a1667bf0af53fb3f836d56b7ab7ec728c"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1497,8 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3931e41a6feae1819c59788d2a0a4a08fa51bac3024b63cec4fb88d13882dbee"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1517,8 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856e37bcabd67cf26934bd127189844b9fc40004fb545b80bef899bef9092df3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1535,8 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b203c12236140e627270c4d7d469ab2e776a94c22da9051b020303bc6b21f"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1558,8 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1b9b6000e8f55cc09e00f7552a7c4acb8c42548ef76088e2154ca839387aba"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1569,8 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195c93f19d8c9c6e36e518656ca381cd4f86131515ad4e99f7e6d2a1836b7b7e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1583,8 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90d27386ce69af9d3e3c63e590cf6e1d466f948c2b3e2b0911872cb6d88adf5b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1598,8 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0eb1d08a424a2d714652aca4c2738a016c90f4eb78f6f64913f9fe2c77fe34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1608,8 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95544f3bc56c8c9cc335910d5aa567a6743a3aeeb33084bb3e31dc6801936edb"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1640,8 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-query"
-version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93a963dcbb97c796c236e6a20367e3db6c3f43c472ead4cde037460a175a48e"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3566,3 +3593,13 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[patch.unused]]
+name = "ibc"
+version = "0.53.0"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"
+
+[[patch.unused]]
+name = "ibc-query"
+version = "0.53.0"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=6c7a65e#6c7a65e646f7bcae1d4ba6c9054059ca966bb979"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ tendermint-rpc   = { version = "0.38", default-features = false }
 tower-abci = { version = "0.16" }
 
 [patch.crates-io]
-ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "6c7a65e" }
-ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "6c7a65e" }
+ibc       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "a36348b" }
+ibc-query = { git = "https://github.com/cosmos/ibc-rs.git", rev = "a36348b" }
 
 # for tendermint 0.38
 tower-abci = { git = "https://github.com/informalsystems/tower-abci", rev = "0992541" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tracing            = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 # ibc dependencies
-ibc       = { version = "0.53.0", default-features = false, features = [ "serde" ] }
-ibc-query = { version = "0.53.0", default-features = false }
+ibc       = { version = "0.54.0", default-features = false, features = [ "serde" ] }
+ibc-query = { version = "0.54.0", default-features = false }
 ibc-proto = { version = "0.47.0", default-features = false }
 ics23     = { version = "0.12", default-features = false }
 

--- a/basecoin/modules/src/ibc/transfer.rs
+++ b/basecoin/modules/src/ibc/transfer.rs
@@ -60,7 +60,7 @@ where
             ACCOUNT_PREFIX,
             &cosmos_adr028_escrow_address(port_id, channel_id),
         )
-        .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+        .map_err(|_| TokenTransferError::FailedToParseAccount)?;
 
         Ok(account_id)
     }
@@ -379,12 +379,12 @@ where
         let from = from_account
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let to = self
             .get_escrow_account(port_id, channel_id)?
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let coins = vec![Coin {
             denom: Denom(coin.denom.to_string()),
             amount: coin.amount.into(),
@@ -404,11 +404,11 @@ where
             .get_escrow_account(port_id, channel_id)?
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let to = to_account
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let coins = vec![Coin {
             denom: Denom(coin.denom.to_string()),
             amount: coin.amount.into(),
@@ -425,7 +425,7 @@ where
         let account = account
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let coins = vec![Coin {
             denom: Denom(amt.denom.to_string()),
             amount: amt.amount.into(),
@@ -443,7 +443,7 @@ where
         let account = account
             .to_string()
             .parse()
-            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+            .map_err(|_| TokenTransferError::FailedToParseAccount)?;
         let coins = vec![Coin {
             denom: Denom(amt.denom.to_string()),
             amount: amt.amount.into(),


### PR DESCRIPTION
This PR patches basecoin to the latest revision of ibc-rs PR [1318](https://github.com/cosmos/ibc-rs/pull/1318), which cleans up the errors contained within the `ibc-apps` crate.